### PR TITLE
do not sleep through a context timeout

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -198,7 +198,15 @@ func retryHTTP(
 		}
 		fullURL = rIDReplacer.replace()
 		glog.V(2).Infof("sleeping %v. to timeout: %v. retrying", sleepTime, totalTimeout)
-		time.Sleep(sleepTime)
+
+		await := time.NewTimer(sleepTime)
+		select {
+		case <-await.C:
+			// retry the request
+		case <-ctx.Done():
+			await.Stop()
+			return res, ctx.Err()
+		}
 	}
 	return res, err
 }


### PR DESCRIPTION
The title says it all! This changes the unconditional sleep to instead select on a timer or the context. 