### PR TITLE
make use of Context more consistent across functions and fn pointers

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -109,6 +109,7 @@ type authResponse struct {
 }
 
 func postAuth(
+	ctx context.Context,
 	sr *snowflakeRestful,
 	params *url.Values,
 	headers map[string]string,
@@ -121,7 +122,7 @@ func postAuth(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port,
 		"/session/v1/login-request?"+params.Encode())
 	glog.V(2).Infof("full URL: %v", fullURL)
-	resp, err := sr.FuncPost(context.TODO(), sr, fullURL, headers, body, timeout, true)
+	resp, err := sr.FuncPost(ctx, sr, fullURL, headers, body, timeout, true)
 	if err != nil {
 		return nil, err
 	}
@@ -183,6 +184,7 @@ func getHeaders() map[string]string {
 
 // Used to authenticate the user with Snowflake.
 func authenticate(
+	ctx context.Context,
 	sc *snowflakeConn,
 	samlResponse []byte,
 	proofKey []byte,
@@ -271,7 +273,7 @@ func authenticate(
 	glog.V(2).Infof("PARAMS for Auth: %v, %v, %v, %v, %v, %v",
 		params, sc.rest.Protocol, sc.rest.Host, sc.rest.Port, sc.rest.LoginTimeout, sc.rest.Authenticator)
 
-	respd, err := sc.rest.FuncPostAuth(sc.rest, params, headers, jsonBody, sc.rest.LoginTimeout)
+	respd, err := sc.rest.FuncPostAuth(ctx, sc.rest, params, headers, jsonBody, sc.rest.LoginTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/auth_go1_10_test.go
+++ b/auth_go1_10_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Snowflake Computing Inc. All right reserved.
+// Copyright (c) 2016-2018 Snowflake Computing Inc. All right reserved.
 // +build go1.10
 
 package gosnowflake
@@ -7,6 +7,7 @@ package gosnowflake
 // Golang version 1.10 or upper
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"testing"
@@ -26,7 +27,7 @@ func TestUnitAuthenticateJWT(t *testing.T) {
 	sc.rest = sr
 
 	// A valid JWT token should pass
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err != nil {
 		t.Fatalf("failed to run. err: %v", err)
 	}
@@ -34,7 +35,7 @@ func TestUnitAuthenticateJWT(t *testing.T) {
 	// An invalid JWT token should not pass
 	invalidPrivateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	sc.cfg.PrivateKey = invalidPrivateKey
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatalf("invalid token passed")
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -3,6 +3,7 @@
 package gosnowflake
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,51 +20,51 @@ func TestUnitPostAuth(t *testing.T) {
 		FuncPost: postTestAfterRenew,
 	}
 	var err error
-	_, err = postAuth(sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
+	_, err = postAuth(context.TODO(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	sr.FuncPost = postTestError
-	_, err = postAuth(sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
+	_, err = postAuth(context.TODO(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
 	if err == nil {
 		t.Fatal("should have failed to auth for unknown reason")
 	}
 	sr.FuncPost = postTestAppBadGatewayError
-	_, err = postAuth(sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
+	_, err = postAuth(context.TODO(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
 	if err == nil {
 		t.Fatal("should have failed to auth for unknown reason")
 	}
 	sr.FuncPost = postTestAppForbiddenError
-	_, err = postAuth(sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
+	_, err = postAuth(context.TODO(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
 	if err == nil {
 		t.Fatal("should have failed to auth for unknown reason")
 	}
 	sr.FuncPost = postTestAppUnexpectedError
-	_, err = postAuth(sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
+	_, err = postAuth(context.TODO(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
 	if err == nil {
 		t.Fatal("should have failed to auth for unknown reason")
 	}
 }
 
-func postAuthFailServiceIssue(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthFailServiceIssue(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return nil, &SnowflakeError{
 		Number: ErrCodeServiceUnavailable,
 	}
 }
 
-func postAuthFailWrongAccount(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthFailWrongAccount(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return nil, &SnowflakeError{
 		Number: ErrCodeFailedToConnect,
 	}
 }
 
-func postAuthFailUnknown(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthFailUnknown(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return nil, &SnowflakeError{
 		Number: ErrFailedToAuth,
 	}
 }
 
-func postAuthSuccessWithErrorCode(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthSuccessWithErrorCode(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return &authResponse{
 		Success: false,
 		Code:    "98765",
@@ -71,7 +72,7 @@ func postAuthSuccessWithErrorCode(_ *snowflakeRestful, _ *url.Values, _ map[stri
 	}, nil
 }
 
-func postAuthSuccessWithInvalidErrorCode(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthSuccessWithInvalidErrorCode(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return &authResponse{
 		Success: false,
 		Code:    "abcdef",
@@ -79,7 +80,7 @@ func postAuthSuccessWithInvalidErrorCode(_ *snowflakeRestful, _ *url.Values, _ m
 	}, nil
 }
 
-func postAuthSuccess(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthSuccess(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return &authResponse{
 		Success: true,
 		Data: authResponseMain{
@@ -92,7 +93,7 @@ func postAuthSuccess(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ 
 	}, nil
 }
 
-func postAuthCheckSAMLResponse(_ *snowflakeRestful, _ *url.Values, _ map[string]string, jsonBody []byte, _ time.Duration) (*authResponse, error) {
+func postAuthCheckSAMLResponse(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, jsonBody []byte, _ time.Duration) (*authResponse, error) {
 	var ar authRequest
 	if err := json.Unmarshal(jsonBody, &ar); err != nil {
 		return nil, err
@@ -115,6 +116,7 @@ func postAuthCheckSAMLResponse(_ *snowflakeRestful, _ *url.Values, _ map[string]
 // Checks that the request body generated when authenticating with OAuth
 // contains all the necessary values.
 func postAuthCheckOAuth(
+	_ context.Context,
 	_ *snowflakeRestful,
 	_ *url.Values, _ map[string]string,
 	jsonBody []byte,
@@ -144,7 +146,7 @@ func postAuthCheckOAuth(
 	}, nil
 }
 
-func postAuthCheckPasscode(_ *snowflakeRestful, _ *url.Values, _ map[string]string, jsonBody []byte, _ time.Duration) (*authResponse, error) {
+func postAuthCheckPasscode(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, jsonBody []byte, _ time.Duration) (*authResponse, error) {
 	var ar authRequest
 	if err := json.Unmarshal(jsonBody, &ar); err != nil {
 		return nil, err
@@ -164,7 +166,7 @@ func postAuthCheckPasscode(_ *snowflakeRestful, _ *url.Values, _ map[string]stri
 	}, nil
 }
 
-func postAuthCheckPasscodeInPassword(_ *snowflakeRestful, _ *url.Values, _ map[string]string, jsonBody []byte, _ time.Duration) (*authResponse, error) {
+func postAuthCheckPasscodeInPassword(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, jsonBody []byte, _ time.Duration) (*authResponse, error) {
 	var ar authRequest
 	if err := json.Unmarshal(jsonBody, &ar); err != nil {
 		return nil, err
@@ -186,7 +188,7 @@ func postAuthCheckPasscodeInPassword(_ *snowflakeRestful, _ *url.Values, _ map[s
 
 // JWT token validate callback function to check the JWT token
 // It uses the public key paired with the testPrivKey
-func postAuthCheckJWTToken(_ *snowflakeRestful, _ *url.Values, _ map[string]string, jsonBody []byte, _ time.Duration) (*authResponse, error) {
+func postAuthCheckJWTToken(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, jsonBody []byte, _ time.Duration) (*authResponse, error) {
 	var ar authRequest
 	if err := json.Unmarshal(jsonBody, &ar); err != nil {
 		return nil, err
@@ -252,7 +254,7 @@ func TestUnitAuthenticate(t *testing.T) {
 	}
 	sc.rest = sr
 
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
@@ -261,7 +263,7 @@ func TestUnitAuthenticate(t *testing.T) {
 		t.Fatalf("Snowflake error is expected. err: %v", driverErr)
 	}
 	sr.FuncPostAuth = postAuthFailWrongAccount
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
@@ -270,7 +272,7 @@ func TestUnitAuthenticate(t *testing.T) {
 		t.Fatalf("Snowflake error is expected. err: %v", driverErr)
 	}
 	sr.FuncPostAuth = postAuthFailUnknown
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
@@ -279,7 +281,7 @@ func TestUnitAuthenticate(t *testing.T) {
 		t.Fatalf("Snowflake error is expected. err: %v", driverErr)
 	}
 	sr.FuncPostAuth = postAuthSuccessWithErrorCode
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
@@ -288,13 +290,13 @@ func TestUnitAuthenticate(t *testing.T) {
 		t.Fatalf("Snowflake error is expected. err: %v", driverErr)
 	}
 	sr.FuncPostAuth = postAuthSuccessWithInvalidErrorCode
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncPostAuth = postAuthSuccess
 	var resp *authResponseMain
-	resp, err = authenticate(sc, []byte{}, []byte{})
+	resp, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err != nil {
 		t.Fatalf("failed to auth. err: %v", err)
 	}
@@ -311,7 +313,7 @@ func TestUnitAuthenticateSaml(t *testing.T) {
 	sc := getDefaultSnowflakeConn()
 	sc.cfg.Authenticator = authenticatorOkta
 	sc.rest = sr
-	_, err = authenticate(sc, []byte("HTML data in bytes from"), []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte("HTML data in bytes from"), []byte{})
 	if err != nil {
 		t.Fatalf("failed to run. err: %v", err)
 	}
@@ -327,7 +329,7 @@ func TestUnitAuthenticateOAuth(t *testing.T) {
 	sc.cfg.Token = "oauthToken"
 	sc.cfg.Authenticator = authenticatorOAuth
 	sc.rest = sr
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err != nil {
 		t.Fatalf("failed to run. err: %v", err)
 	}
@@ -342,14 +344,14 @@ func TestUnitAuthenticatePasscode(t *testing.T) {
 	sc.cfg.Passcode = "987654321"
 	sc.rest = sr
 
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err != nil {
 		t.Fatalf("failed to run. err: %v", err)
 	}
 	sr.FuncPostAuth = postAuthCheckPasscodeInPassword
 	sc.rest = sr
 	sc.cfg.PasscodeInPassword = true
-	_, err = authenticate(sc, []byte{}, []byte{})
+	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err != nil {
 		t.Fatalf("failed to run. err: %v", err)
 	}

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -6,6 +6,7 @@ package gosnowflake
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -81,6 +82,7 @@ func openBrowser(idpURL string) error {
 // Note: FuncPostAuthSaml will return a fully qualified error if
 // there is something wrong getting data from Snowflake.
 func getIdpURLProofKey(
+	ctx context.Context,
 	sr *snowflakeRestful,
 	authenticator string,
 	application string,
@@ -117,7 +119,7 @@ func getIdpURLProofKey(
 		return "", "", err
 	}
 
-	respd, err := sr.FuncPostAuthSAML(sr, headers, jsonBody, sr.LoginTimeout)
+	respd, err := sr.FuncPostAuthSAML(ctx, sr, headers, jsonBody, sr.LoginTimeout)
 	if err != nil {
 		return "", "", err
 	}
@@ -162,6 +164,7 @@ func getTokenFromResponse(response string) (string, error) {
 // - Snowflake directs the user back to the driver
 // - authenticate is complete!
 func authenticateByExternalBrowser(
+	ctx context.Context,
 	sr *snowflakeRestful,
 	authenticator string,
 	application string,
@@ -177,7 +180,7 @@ func authenticateByExternalBrowser(
 
 	callbackPort := l.Addr().(*net.TCPAddr).Port
 	idpURL, proofKey, err := getIdpURLProofKey(
-		sr, authenticator, application, account, callbackPort)
+		ctx, sr, authenticator, application, account, callbackPort)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/authokta.go
+++ b/authokta.go
@@ -51,6 +51,7 @@ Explanation:
 	another SP.
 */
 func authenticateBySAML(
+	ctx context.Context,
 	sr *snowflakeRestful,
 	authenticator string,
 	application string,
@@ -85,7 +86,7 @@ func authenticateBySAML(
 		return nil, err
 	}
 	glog.V(2).Infof("PARAMS for Auth: %v, %v", params, sr)
-	respd, err := sr.FuncPostAuthSAML(sr, headers, jsonBody, sr.LoginTimeout)
+	respd, err := sr.FuncPostAuthSAML(ctx, sr, headers, jsonBody, sr.LoginTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +131,7 @@ func authenticateBySAML(
 	if err != nil {
 		return nil, err
 	}
-	respa, err := sr.FuncPostAuthOKTA(sr, headers, jsonBody, respd.Data.TokenURL, sr.LoginTimeout)
+	respa, err := sr.FuncPostAuthOKTA(ctx, sr, headers, jsonBody, respd.Data.TokenURL, sr.LoginTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +143,7 @@ func authenticateBySAML(
 
 	headers = make(map[string]string)
 	headers["accept"] = "*/*"
-	bd, err := sr.FuncGetSSO(sr, params, headers, respd.Data.SSOURL, sr.LoginTimeout)
+	bd, err := sr.FuncGetSSO(ctx, sr, params, headers, respd.Data.SSOURL, sr.LoginTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -210,6 +211,7 @@ func isPrefixEqual(url1 string, url2 string) (bool, error) {
 // Makes a request to /session/authenticator-request to get SAML Information,
 // such as the IDP Url and Proof Key, depending on the authenticator
 func postAuthSAML(
+	ctx context.Context,
 	sr *snowflakeRestful,
 	headers map[string]string,
 	body []byte,
@@ -220,7 +222,7 @@ func postAuthSAML(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port,
 		"/session/authenticator-request?"+requestID)
 	glog.V(2).Infof("fullURL: %v", fullURL)
-	resp, err := sr.FuncPost(context.TODO(), sr, fullURL, headers, body, timeout, true)
+	resp, err := sr.FuncPost(ctx, sr, fullURL, headers, body, timeout, true)
 	if err != nil {
 		return nil, err
 	}
@@ -270,6 +272,7 @@ func postAuthSAML(
 }
 
 func postAuthOKTA(
+	ctx context.Context,
 	sr *snowflakeRestful,
 	headers map[string]string,
 	body []byte,
@@ -277,7 +280,7 @@ func postAuthOKTA(
 	timeout time.Duration) (
 	data *authOKTAResponse, err error) {
 	glog.V(2).Infof("fullURL: %v", fullURL)
-	resp, err := sr.FuncPost(context.TODO(), sr, fullURL, headers, body, timeout, false)
+	resp, err := sr.FuncPost(ctx, sr, fullURL, headers, body, timeout, false)
 	if err != nil {
 		return nil, err
 	}
@@ -311,6 +314,7 @@ func postAuthOKTA(
 }
 
 func getSSO(
+	ctx context.Context,
 	sr *snowflakeRestful,
 	params *url.Values,
 	headers map[string]string,
@@ -319,7 +323,7 @@ func getSSO(
 	bd []byte, err error) {
 	fullURL := fmt.Sprintf("%s?%s", url, params.Encode())
 	glog.V(2).Infof("fullURL: %v", fullURL)
-	resp, err := sr.FuncGet(context.TODO(), sr, fullURL, headers, timeout)
+	resp, err := sr.FuncGet(ctx, sr, fullURL, headers, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/authokta_test.go
+++ b/authokta_test.go
@@ -97,17 +97,17 @@ func TestUnitPostAuthSAML(t *testing.T) {
 		FuncPost: postTestError,
 	}
 	var err error
-	_, err = postAuthSAML(sr, make(map[string]string), []byte{}, 0)
+	_, err = postAuthSAML(context.TODO(), sr, make(map[string]string), []byte{}, 0)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncPost = postTestAppBadGatewayError
-	_, err = postAuthSAML(sr, make(map[string]string), []byte{}, 0)
+	_, err = postAuthSAML(context.TODO(), sr, make(map[string]string), []byte{}, 0)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncPost = postTestSuccessButInvalidJSON
-	_, err = postAuthSAML(sr, make(map[string]string), []byte{0x12, 0x34}, 0)
+	_, err = postAuthSAML(context.TODO(), sr, make(map[string]string), []byte{0x12, 0x34}, 0)
 	if err == nil {
 		t.Fatalf("should have failed to post")
 	}
@@ -118,17 +118,17 @@ func TestUnitPostAuthOKTA(t *testing.T) {
 		FuncPost: postTestError,
 	}
 	var err error
-	_, err = postAuthOKTA(sr, make(map[string]string), []byte{}, "hahah", 0)
+	_, err = postAuthOKTA(context.TODO(), sr, make(map[string]string), []byte{}, "hahah", 0)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncPost = postTestAppBadGatewayError
-	_, err = postAuthOKTA(sr, make(map[string]string), []byte{}, "hahah", 0)
+	_, err = postAuthOKTA(context.TODO(), sr, make(map[string]string), []byte{}, "hahah", 0)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncPost = postTestSuccessButInvalidJSON
-	_, err = postAuthOKTA(sr, make(map[string]string), []byte{0x12, 0x34}, "haha", 0)
+	_, err = postAuthOKTA(context.TODO(), sr, make(map[string]string), []byte{0x12, 0x34}, "haha", 0)
 	if err == nil {
 		t.Fatal("should have failed to run post request after the renewal")
 	}
@@ -139,34 +139,34 @@ func TestUnitGetSSO(t *testing.T) {
 		FuncGet: getTestError,
 	}
 	var err error
-	_, err = getSSO(sr, &url.Values{}, make(map[string]string), "hahah", 0)
+	_, err = getSSO(context.TODO(), sr, &url.Values{}, make(map[string]string), "hahah", 0)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncGet = getTestAppBadGatewayError
-	_, err = getSSO(sr, &url.Values{}, make(map[string]string), "hahah", 0)
+	_, err = getSSO(context.TODO(), sr, &url.Values{}, make(map[string]string), "hahah", 0)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncGet = getTestHTMLSuccess
-	_, err = getSSO(sr, &url.Values{}, make(map[string]string), "hahah", 0)
+	_, err = getSSO(context.TODO(), sr, &url.Values{}, make(map[string]string), "hahah", 0)
 	if err != nil {
 		t.Fatalf("failed to get HTML content. err: %v", err)
 	}
 }
 
-func postAuthSAMLError(_ *snowflakeRestful, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthSAMLError(_ context.Context, _ *snowflakeRestful, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return &authResponse{}, errors.New("failed to get SAML response")
 }
 
-func postAuthSAMLAuthFail(_ *snowflakeRestful, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthSAMLAuthFail(_ context.Context, _ *snowflakeRestful, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return &authResponse{
 		Success: false,
 		Message: "SAML auth failed",
 	}, nil
 }
 
-func postAuthSAMLAuthSuccessButInvalidURL(_ *snowflakeRestful, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthSAMLAuthSuccessButInvalidURL(_ context.Context, _ *snowflakeRestful, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return &authResponse{
 		Success: true,
 		Message: "",
@@ -177,7 +177,7 @@ func postAuthSAMLAuthSuccessButInvalidURL(_ *snowflakeRestful, _ map[string]stri
 	}, nil
 }
 
-func postAuthSAMLAuthSuccess(_ *snowflakeRestful, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
+func postAuthSAMLAuthSuccess(_ context.Context, _ *snowflakeRestful, _ map[string]string, _ []byte, _ time.Duration) (*authResponse, error) {
 	return &authResponse{
 		Success: true,
 		Message: "",
@@ -188,23 +188,23 @@ func postAuthSAMLAuthSuccess(_ *snowflakeRestful, _ map[string]string, _ []byte,
 	}, nil
 }
 
-func postAuthOKTAError(_ *snowflakeRestful, _ map[string]string, _ []byte, _ string, _ time.Duration) (*authOKTAResponse, error) {
+func postAuthOKTAError(_ context.Context, _ *snowflakeRestful, _ map[string]string, _ []byte, _ string, _ time.Duration) (*authOKTAResponse, error) {
 	return &authOKTAResponse{}, errors.New("failed to get SAML response")
 }
 
-func postAuthOKTASuccess(_ *snowflakeRestful, _ map[string]string, _ []byte, _ string, _ time.Duration) (*authOKTAResponse, error) {
+func postAuthOKTASuccess(_ context.Context, _ *snowflakeRestful, _ map[string]string, _ []byte, _ string, _ time.Duration) (*authOKTAResponse, error) {
 	return &authOKTAResponse{}, nil
 }
 
-func getSSOError(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ string, _ time.Duration) ([]byte, error) {
+func getSSOError(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ string, _ time.Duration) ([]byte, error) {
 	return []byte{}, errors.New("failed to get SSO html")
 }
 
-func getSSOSuccessButInvalidURL(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ string, _ time.Duration) ([]byte, error) {
+func getSSOSuccessButInvalidURL(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ string, _ time.Duration) ([]byte, error) {
 	return []byte(`<html><form id="1"/></html>`), nil
 }
 
-func getSSOSuccess(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ string, _ time.Duration) ([]byte, error) {
+func getSSOSuccess(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ string, _ time.Duration) ([]byte, error) {
 	return []byte(`<html><form id="1" action="https&#x3a;&#x2f;&#x2f;abc.com&#x2f;"></form></html>`), nil
 }
 
@@ -221,17 +221,17 @@ func TestUnitAuthenticateBySAML(t *testing.T) {
 		FuncPostAuthSAML: postAuthSAMLError,
 	}
 	var err error
-	_, err = authenticateBySAML(sr, authenticator, application, account, user, password)
+	_, err = authenticateBySAML(context.TODO(), sr, authenticator, application, account, user, password)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncPostAuthSAML = postAuthSAMLAuthFail
-	_, err = authenticateBySAML(sr, authenticator, application, account, user, password)
+	_, err = authenticateBySAML(context.TODO(), sr, authenticator, application, account, user, password)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncPostAuthSAML = postAuthSAMLAuthSuccessButInvalidURL
-	_, err = authenticateBySAML(sr, authenticator, application, account, user, password)
+	_, err = authenticateBySAML(context.TODO(), sr, authenticator, application, account, user, password)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
@@ -244,23 +244,23 @@ func TestUnitAuthenticateBySAML(t *testing.T) {
 	}
 	sr.FuncPostAuthSAML = postAuthSAMLAuthSuccess
 	sr.FuncPostAuthOKTA = postAuthOKTAError
-	_, err = authenticateBySAML(sr, authenticator, application, account, user, password)
+	_, err = authenticateBySAML(context.TODO(), sr, authenticator, application, account, user, password)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncPostAuthOKTA = postAuthOKTASuccess
 	sr.FuncGetSSO = getSSOError
-	_, err = authenticateBySAML(sr, authenticator, application, account, user, password)
+	_, err = authenticateBySAML(context.TODO(), sr, authenticator, application, account, user, password)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncGetSSO = getSSOSuccessButInvalidURL
-	_, err = authenticateBySAML(sr, authenticator, application, account, user, password)
+	_, err = authenticateBySAML(context.TODO(), sr, authenticator, application, account, user, password)
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
 	sr.FuncGetSSO = getSSOSuccess
-	_, err = authenticateBySAML(sr, authenticator, application, account, user, password)
+	_, err = authenticateBySAML(context.TODO(), sr, authenticator, application, account, user, password)
 	if err != nil {
 		t.Fatalf("failed. err: %v", err)
 	}

--- a/connection.go
+++ b/connection.go
@@ -170,11 +170,13 @@ func (sc *snowflakeConn) Close() (err error) {
 	sc.stopHeartBeat()
 
 	// ensure transaction is rollbacked
-	_, err = sc.exec(context.Background(), "ROLLBACK", false, false, nil)
+	ctx := context.TODO()
+	_, err = sc.exec(ctx, "ROLLBACK", false, false, nil)
 	if err != nil {
 		glog.V(2).Info(err)
 	}
-	err = sc.rest.FuncCloseSession(sc.rest)
+
+	err = sc.rest.FuncCloseSession(ctx, sc.rest)
 	if err != nil {
 		glog.V(2).Info(err)
 	}

--- a/driver.go
+++ b/driver.go
@@ -3,6 +3,7 @@
 package gosnowflake
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"net/http"
@@ -15,6 +16,8 @@ type SnowflakeDriver struct{}
 // Open creates a new connection.
 func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 	glog.V(2).Info("Open")
+	ctx := context.TODO()
+
 	var err error
 	sc := &snowflakeConn{
 		SequeceCounter: 0,
@@ -66,6 +69,7 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 	switch authenticator {
 	case authenticatorExternalBrowser:
 		samlResponse, proofKey, err = authenticateByExternalBrowser(
+			ctx,
 			sc.rest,
 			sc.cfg.Authenticator,
 			sc.cfg.Application,
@@ -84,6 +88,7 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 	default:
 		// this is actually okta, which is something misleading
 		samlResponse, err = authenticateBySAML(
+			ctx,
 			sc.rest,
 			sc.cfg.Authenticator,
 			sc.cfg.Application,
@@ -96,6 +101,7 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 		}
 	}
 	authData, err = authenticate(
+		ctx,
 		sc,
 		samlResponse,
 		proofKey)

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -66,7 +66,7 @@ func (hc *heartbeat) heartbeatMain() error {
 	headers["User-Agent"] = userAgent
 	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, hc.restful.Token)
 
-	resp, err := hc.restful.FuncPost(context.TODO(), hc.restful, fullURL, headers, nil, hc.restful.RequestTimeout, false)
+	resp, err := hc.restful.FuncPost(context.Background(), hc.restful, fullURL, headers, nil, hc.restful.RequestTimeout, false)
 	if err != nil {
 		return err
 	}

--- a/ocsp.go
+++ b/ocsp.go
@@ -256,6 +256,7 @@ func validateOCSP(encodedCertIDBase64 string, ocspRes *ocsp.Response, subject *x
 // retryOCSP is the second level of retry method if the returned contents are corrupted. It often happens with OCSP
 // serer and retry helps.
 func retryOCSP(
+	ctx context.Context,
 	client clientInterface,
 	req requestFunc,
 	ocspHost string,
@@ -271,7 +272,7 @@ func retryOCSP(
 	sleepTime := time.Duration(0)
 	for {
 		sleepTime = defaultWaitAlgo.decorr(retryCounter, sleepTime)
-		res, err := retryHTTP(context.TODO(), client, req, "POST", ocspHost, headers, reqBody, httpTimeout, false)
+		res, err := retryHTTP(ctx, client, req, "POST", ocspHost, headers, reqBody, httpTimeout, false)
 		if err != nil {
 			if ok := retryRevocationStatusCheck(&totalTimeout, sleepTime); ok {
 				retryCounter++
@@ -327,7 +328,7 @@ func retryOCSP(
 }
 
 // getRevocationStatus checks the certificate revocation status for subject using issuer certificate.
-func getRevocationStatus(wg *sync.WaitGroup, ocspStatusChan chan<- *ocspStatus, subject, issuer *x509.Certificate) {
+func getRevocationStatus(ctx context.Context, wg *sync.WaitGroup, ocspStatusChan chan<- *ocspStatus, subject, issuer *x509.Certificate) {
 	defer wg.Done()
 	glog.V(2).Infof("Subject: %v\n", subject.Subject)
 	glog.V(2).Infof("Issuer:  %v\n", issuer.Subject)
@@ -380,7 +381,7 @@ func getRevocationStatus(wg *sync.WaitGroup, ocspStatusChan chan<- *ocspStatus, 
 	headers["Accept"] = "application/ocsp-response"
 	headers["Content-Length"] = string(len(ocspReq))
 	headers["Host"] = u.Hostname()
-	ocspRes, ocspResBytes, ocspS := retryOCSP(ocspClient, http.NewRequest, ocspHost, headers, ocspReq, issuer, retryOCSPTimeout, retryOCSPHTTPTimeout)
+	ocspRes, ocspResBytes, ocspS := retryOCSP(ctx, ocspClient, http.NewRequest, ocspHost, headers, ocspReq, issuer, retryOCSPTimeout, retryOCSPHTTPTimeout)
 	if ocspS.code != ocspSuccess {
 		ocspStatusChan <- ocspS
 		return
@@ -394,7 +395,7 @@ func getRevocationStatus(wg *sync.WaitGroup, ocspStatusChan chan<- *ocspStatus, 
 }
 
 // verifyPeerCertificate verifies all of certificate revocation status
-func verifyPeerCertificate(callback func(*sync.WaitGroup, []*x509.Certificate) []*ocspStatus, verifiedChains [][]*x509.Certificate) (err error) {
+func verifyPeerCertificate(callback func(context.Context, *sync.WaitGroup, []*x509.Certificate) []*ocspStatus, verifiedChains [][]*x509.Certificate) (err error) {
 	for i := 0; i < len(verifiedChains); i++ {
 		var wg sync.WaitGroup
 		n := len(verifiedChains[i]) - 1
@@ -408,7 +409,7 @@ func verifyPeerCertificate(callback func(*sync.WaitGroup, []*x509.Certificate) [
 			n++
 		}
 		wg.Add(n)
-		results := callback(&wg, verifiedChains[i])
+		results := callback(context.TODO(), &wg, verifiedChains[i])
 		wg.Wait()
 		for _, r := range results {
 			if r.err != nil {
@@ -420,11 +421,11 @@ func verifyPeerCertificate(callback func(*sync.WaitGroup, []*x509.Certificate) [
 	return nil
 }
 
-func getAllRevocationStatusParallel(wg *sync.WaitGroup, verifiedChains []*x509.Certificate) []*ocspStatus {
+func getAllRevocationStatusParallel(ctx context.Context, wg *sync.WaitGroup, verifiedChains []*x509.Certificate) []*ocspStatus {
 	n := len(verifiedChains) - 1
 	ocspStatusChan := make(chan *ocspStatus, n)
 	for j := 0; j < n; j++ {
-		go getRevocationStatus(wg, ocspStatusChan, verifiedChains[j], verifiedChains[j+1])
+		go getRevocationStatus(ctx, wg, ocspStatusChan, verifiedChains[j], verifiedChains[j+1])
 	}
 	results := make([]*ocspStatus, n)
 	for j := 0; j < n; j++ {
@@ -434,12 +435,12 @@ func getAllRevocationStatusParallel(wg *sync.WaitGroup, verifiedChains []*x509.C
 	return results
 }
 
-func getAllRevocationStatusSerial(wg *sync.WaitGroup, verifiedChains []*x509.Certificate) []*ocspStatus {
+func getAllRevocationStatusSerial(ctx context.Context, wg *sync.WaitGroup, verifiedChains []*x509.Certificate) []*ocspStatus {
 	n := len(verifiedChains) - 1
 	results := make([]*ocspStatus, n)
 	for j := 0; j < n; j++ {
 		ocspStatusChan := make(chan *ocspStatus, 1)
-		getRevocationStatus(wg, ocspStatusChan, verifiedChains[j], verifiedChains[j+1])
+		getRevocationStatus(ctx, wg, ocspStatusChan, verifiedChains[j], verifiedChains[j+1])
 		results[j] = <-ocspStatusChan
 		close(ocspStatusChan)
 	}

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -4,6 +4,7 @@ package gosnowflake
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
@@ -265,6 +266,7 @@ func TestOCSPRetry(t *testing.T) {
 		body:    []byte{1, 2, 3},
 	}
 	res, b, st := retryOCSP(
+		context.TODO(),
 		client, fakeRequestFunc,
 		"dummyOCSPHost",
 		make(map[string]string), []byte{0}, certs[len(certs)-1], 20*time.Second, 10*time.Second)
@@ -277,6 +279,7 @@ func TestOCSPRetry(t *testing.T) {
 		body:    []byte{1, 2, 3},
 	}
 	res, b, st = retryOCSP(
+		context.TODO(),
 		client, fakeRequestFunc,
 		"dummyOCSPHost",
 		make(map[string]string), []byte{0}, certs[len(certs)-1], 10*time.Second, 5*time.Second)

--- a/restful_test.go
+++ b/restful_test.go
@@ -176,22 +176,22 @@ func TestUnitCloseSession(t *testing.T) {
 	sr := &snowflakeRestful{
 		FuncPost: postTestAfterRenew,
 	}
-	err := closeSession(sr)
+	err := closeSession(context.Background(), sr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	sr.FuncPost = postTestError
-	err = closeSession(sr)
+	err = closeSession(context.Background(), sr)
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
 	sr.FuncPost = postTestAppBadGatewayError
-	err = closeSession(sr)
+	err = closeSession(context.Background(), sr)
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
 	sr.FuncPost = postTestSuccessButInvalidJSON
-	err = closeSession(sr)
+	err = closeSession(context.Background(), sr)
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
@@ -201,22 +201,22 @@ func TestUnitCancelQuery(t *testing.T) {
 	sr := &snowflakeRestful{
 		FuncPost: postTestAfterRenew,
 	}
-	err := cancelQuery(sr, "abcdefg")
+	err := cancelQuery(context.Background(), sr, "abcdefg")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	sr.FuncPost = postTestError
-	err = cancelQuery(sr, "abcdefg")
+	err = cancelQuery(context.Background(), sr, "abcdefg")
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
 	sr.FuncPost = postTestAppBadGatewayError
-	err = cancelQuery(sr, "abcdefg")
+	err = cancelQuery(context.Background(), sr, "abcdefg")
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
 	sr.FuncPost = postTestSuccessButInvalidJSON
-	err = cancelQuery(sr, "abcdefg")
+	err = cancelQuery(context.Background(), sr, "abcdefg")
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}

--- a/rows.go
+++ b/rows.go
@@ -68,7 +68,7 @@ type snowflakeChunkDownloader struct {
 	Qrmk               string
 	ChunkHeader        map[string]string
 	CurrentIndex       int
-	FuncDownload       func(*snowflakeChunkDownloader, int)
+	FuncDownload       func(context.Context, *snowflakeChunkDownloader, int)
 	FuncDownloadHelper func(context.Context, *snowflakeChunkDownloader, int) error
 	FuncGet            func(context.Context, *snowflakeChunkDownloader, string, map[string]string, time.Duration) (*http.Response, error)
 	DoneDownloadCond   *sync.Cond
@@ -205,7 +205,7 @@ func (scd *snowflakeChunkDownloader) schedule() {
 	select {
 	case nextIdx := <-scd.ChunksChan:
 		glog.V(2).Infof("schedule chunk: %v", nextIdx+1)
-		go scd.FuncDownload(scd, nextIdx)
+		go scd.FuncDownload(scd.ctx, scd, nextIdx)
 	default:
 		// no more download
 		glog.V(2).Info("no more download")
@@ -218,7 +218,7 @@ func (scd *snowflakeChunkDownloader) checkErrorRetry() (err error) {
 		// XXX given that HTTP requests are retried automatically, is this strictly necessary?
 		if scd.ChunksErrorCounter < maxChunkDownloaderErrorCounter && errc.Error != context.Canceled {
 			// add the index to the chunks channel so that the download will be retried.
-			go scd.FuncDownload(scd, errc.Index)
+			go scd.FuncDownload(scd.ctx, scd, errc.Index)
 			scd.ChunksErrorCounter++
 			glog.V(2).Infof("chunk idx: %v, err: %v. retrying (%v/%v)...",
 				errc.Index, errc.Error, scd.ChunksErrorCounter, maxChunkDownloaderErrorCounter)
@@ -325,11 +325,11 @@ func (r *largeResultSetReader) Read(p []byte) (n int, err error) {
 	return 0, io.EOF
 }
 
-func downloadChunk(scd *snowflakeChunkDownloader, idx int) {
+func downloadChunk(ctx context.Context, scd *snowflakeChunkDownloader, idx int) {
 	glog.V(2).Infof("download start chunk: %v", idx+1)
 	defer scd.DoneDownloadCond.Broadcast()
 
-	if err := scd.FuncDownloadHelper(scd.ctx, scd, idx); err != nil {
+	if err := scd.FuncDownloadHelper(ctx, scd, idx); err != nil {
 		glog.V(1).Infof(
 			"failed to extract HTTP response body. URL: %v, err: %v", scd.ChunkMetas[idx].URL, err)
 		glog.Flush()

--- a/rows_test.go
+++ b/rows_test.go
@@ -68,7 +68,7 @@ func TestRowsWithoutChunkDownloader(t *testing.T) {
 
 }
 
-func downloadChunkTest(scd *snowflakeChunkDownloader, idx int) {
+func downloadChunkTest(ctx context.Context, scd *snowflakeChunkDownloader, idx int) {
 	d := make([][]*string, 0)
 	for i := 0; i < rowsInChunk; i++ {
 		v1 := fmt.Sprintf("%v", idx*1000+i)
@@ -138,7 +138,7 @@ func TestRowsWithChunkDownloader(t *testing.T) {
 	glog.V(2).Info("END TESTS")
 }
 
-func downloadChunkTestError(scd *snowflakeChunkDownloader, idx int) {
+func downloadChunkTestError(ctx context.Context, scd *snowflakeChunkDownloader, idx int) {
 	// fail to download 6th and 10th chunk, and retry up to N times and success
 	// NOTE: zero based index
 	scd.ChunksMutex.Lock()
@@ -218,7 +218,7 @@ func TestRowsWithChunkDownloaderError(t *testing.T) {
 	glog.V(2).Info("END TESTS")
 }
 
-func downloadChunkTestErrorFail(scd *snowflakeChunkDownloader, idx int) {
+func downloadChunkTestErrorFail(ctx context.Context, scd *snowflakeChunkDownloader, idx int) {
 	// fail to download 6th and 10th chunk, and retry up to N times and fail
 	// NOTE: zero based index
 	scd.ChunksMutex.Lock()
@@ -323,7 +323,7 @@ func TestDownloadChunkInvalidResponseBody(t *testing.T) {
 	scd.DoneDownloadCond = sync.NewCond(scd.ChunksMutex)
 	scd.Chunks = make(map[int][][]*string)
 	scd.ChunksError = make(chan *chunkError, 1)
-	scd.FuncDownload(scd, 1)
+	scd.FuncDownload(scd.ctx, scd, 1)
 	select {
 	case errc := <-scd.ChunksError:
 		if errc.Index != 1 {
@@ -365,7 +365,7 @@ func TestDownloadChunkErrorStatus(t *testing.T) {
 	scd.DoneDownloadCond = sync.NewCond(scd.ChunksMutex)
 	scd.Chunks = make(map[int][][]*string)
 	scd.ChunksError = make(chan *chunkError, 1)
-	scd.FuncDownload(scd, 1)
+	scd.FuncDownload(scd.ctx, scd, 1)
 	select {
 	case errc := <-scd.ChunksError:
 		if errc.Index != 1 {


### PR DESCRIPTION
This PR should have no functional impact. It just makes the use of `context.Context` more consistent throughout the codebase. That is, it is used as a fn argument wherever possible, and tries to use a user-supplied context where reasonable (rather than using `context.Background()` or `context.TODO()`). 