### PR TITLE
fix requestTimeout cfg bug; small fixes for handling request timeouts

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -176,7 +176,7 @@ func (sc *snowflakeConn) Close() (err error) {
 		glog.V(2).Info(err)
 	}
 
-	err = sc.rest.FuncCloseSession(ctx, sc.rest)
+	err = sc.rest.FuncCloseSession(ctx, sc.rest, sc.rest.RequestTimeout)
 	if err != nil {
 		glog.V(2).Info(err)
 	}

--- a/driver.go
+++ b/driver.go
@@ -35,6 +35,7 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// authenticate
 	sc.rest = &snowflakeRestful{
 		Host:     sc.cfg.Host,

--- a/dsn.go
+++ b/dsn.go
@@ -451,6 +451,11 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			if err != nil {
 				return
 			}
+		case "requestTimeout":
+			cfg.RequestTimeout, err = parseTimeout(value)
+			if err != nil {
+				return
+			}
 		case "jwtTimeout":
 			cfg.JWTExpireTimeout, err = parseTimeout(value)
 			if err != nil {

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -66,7 +66,9 @@ func (hc *heartbeat) heartbeatMain() error {
 	headers["User-Agent"] = userAgent
 	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, hc.restful.Token)
 
-	resp, err := hc.restful.FuncPost(context.Background(), hc.restful, fullURL, headers, nil, hc.restful.RequestTimeout, false)
+	timeout := hc.restful.RequestTimeout
+
+	resp, err := hc.restful.FuncPost(context.Background(), hc.restful, fullURL, headers, nil, timeout, false)
 	if err != nil {
 		return err
 	}
@@ -81,7 +83,7 @@ func (hc *heartbeat) heartbeatMain() error {
 			return err
 		}
 		if respd.Code == sessionExpiredCode {
-			err = hc.restful.FuncRenewSession(context.TODO(), hc.restful)
+			err = hc.restful.FuncRenewSession(context.TODO(), hc.restful, timeout)
 			if err != nil {
 				return err
 			}

--- a/restful_test.go
+++ b/restful_test.go
@@ -118,11 +118,11 @@ func TestUnitPostQueryHelperError(t *testing.T) {
 	}
 }
 
-func renewSessionTest(_ context.Context, _ *snowflakeRestful) error {
+func renewSessionTest(_ context.Context, _ *snowflakeRestful, _ time.Duration) error {
 	return nil
 }
 
-func renewSessionTestError(_ context.Context, _ *snowflakeRestful) error {
+func renewSessionTestError(_ context.Context, _ *snowflakeRestful, _ time.Duration) error {
 	return errors.New("failed to renew session in tests")
 }
 
@@ -151,22 +151,22 @@ func TestUnitRenewRestfulSession(t *testing.T) {
 		Token:       "token",
 		FuncPost:    postTestAfterRenew,
 	}
-	err := renewRestfulSession(context.Background(), sr)
+	err := renewRestfulSession(context.Background(), sr, time.Second)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	sr.FuncPost = postTestError
-	err = renewRestfulSession(context.Background(), sr)
+	err = renewRestfulSession(context.Background(), sr, time.Second)
 	if err == nil {
 		t.Fatal("should have failed to run post request after the renewal")
 	}
 	sr.FuncPost = postTestAppBadGatewayError
-	err = renewRestfulSession(context.Background(), sr)
+	err = renewRestfulSession(context.Background(), sr, time.Second)
 	if err == nil {
 		t.Fatal("should have failed to run post request after the renewal")
 	}
 	sr.FuncPost = postTestSuccessButInvalidJSON
-	err = renewRestfulSession(context.Background(), sr)
+	err = renewRestfulSession(context.Background(), sr, time.Second)
 	if err == nil {
 		t.Fatal("should have failed to run post request after the renewal")
 	}
@@ -176,22 +176,22 @@ func TestUnitCloseSession(t *testing.T) {
 	sr := &snowflakeRestful{
 		FuncPost: postTestAfterRenew,
 	}
-	err := closeSession(context.Background(), sr)
+	err := closeSession(context.Background(), sr, time.Second)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	sr.FuncPost = postTestError
-	err = closeSession(context.Background(), sr)
+	err = closeSession(context.Background(), sr, time.Second)
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
 	sr.FuncPost = postTestAppBadGatewayError
-	err = closeSession(context.Background(), sr)
+	err = closeSession(context.Background(), sr, time.Second)
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
 	sr.FuncPost = postTestSuccessButInvalidJSON
-	err = closeSession(context.Background(), sr)
+	err = closeSession(context.Background(), sr, time.Second)
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
@@ -201,22 +201,22 @@ func TestUnitCancelQuery(t *testing.T) {
 	sr := &snowflakeRestful{
 		FuncPost: postTestAfterRenew,
 	}
-	err := cancelQuery(context.Background(), sr, "abcdefg")
+	err := cancelQuery(context.Background(), sr, "abcdefg", time.Second)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	sr.FuncPost = postTestError
-	err = cancelQuery(context.Background(), sr, "abcdefg")
+	err = cancelQuery(context.Background(), sr, "abcdefg", time.Second)
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
 	sr.FuncPost = postTestAppBadGatewayError
-	err = cancelQuery(context.Background(), sr, "abcdefg")
+	err = cancelQuery(context.Background(), sr, "abcdefg", time.Second)
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}
 	sr.FuncPost = postTestSuccessButInvalidJSON
-	err = cancelQuery(context.Background(), sr, "abcdefg")
+	err = cancelQuery(context.Background(), sr, "abcdefg", time.Second)
 	if err == nil {
 		t.Fatal("should have failed to close session")
 	}

--- a/retry.go
+++ b/retry.go
@@ -4,7 +4,6 @@ package gosnowflake
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"github.com/google/uuid"
 	"io"
@@ -184,12 +183,12 @@ func retryHTTP(
 			totalTimeout -= sleepTime
 			if totalTimeout <= 0 {
 				if err != nil {
-					return nil, fmt.Errorf("timeout. err: %v. Hanging?", err)
+					return nil, fmt.Errorf("timeout after %s. err: %v. Hanging?", timeout, err)
 				}
 				if res != nil {
-					return nil, fmt.Errorf("timeout. HTTP Status: %v. Hanging?", res.StatusCode)
+					return nil, fmt.Errorf("timeout after %s. HTTP Status: %v. Hanging?", timeout, res.StatusCode)
 				}
-				return nil, errors.New("timeout. Hanging?")
+				return nil, fmt.Errorf("timeout after %s. Hanging?", timeout)
 			}
 		}
 		retryCounter++


### PR DESCRIPTION
This PR fixes a `dsn` parsing bug, where the `request timeout` was not being respected. It also adds a `timeout` field to more of the handler functions, so that they don't need to determine what the appropriate timeout is in a given situation. 