### PR TITLE
check err return from FuncGet

### DIFF
--- a/restful.go
+++ b/restful.go
@@ -180,6 +180,10 @@ func postRestfulQueryHelper(
 				"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port, resultURL)
 
 			resp, err = sr.FuncGet(ctx, sr, fullURL, headers, timeout)
+			if err != nil {
+				return nil, err
+			}
+
 			respd = execResponse{} // reset the response
 			err = json.NewDecoder(resp.Body).Decode(&respd)
 			resp.Body.Close()


### PR DESCRIPTION
This check was missing, and could result in a panic if `err` was not `nil`. 