### PR TITLE
respect ocsp flag

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -116,6 +116,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 	if cfg.Application != clientType {
 		params.Add("application", cfg.Application)
 	}
+	if cfg.InsecureMode {
+		params.Add("insecureMode", "true")
+	}
 	if cfg.Protocol != "" && cfg.Protocol != "https" {
 		params.Add("protocol", cfg.Protocol)
 	}


### PR DESCRIPTION
### Description
This PR fixes `dsn.go` to respect the `InsecureMode` flag. 

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
