### PR TITLE
Fix Custom JSON Parser

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -285,6 +285,9 @@ func (lcd *largeChunkDecoder) nextByte() byte {
 func (lcd *largeChunkDecoder) ensureBytes(n int) {
 	if lcd.rem <= n {
 		rbuf := make([]byte, defaultChunkBufferSize)
+		// NOTE when the buffer reads from the stream, there's no
+		// guarantee that it will actually be filled. As such we
+		// must use (ptr+rem) to compute the end of the slice.
 		off := copy(rbuf, lcd.rbuf[lcd.ptr:lcd.ptr+lcd.rem])
 		add := lcd.fillBuffer(rbuf[off:])
 

--- a/chunk.go
+++ b/chunk.go
@@ -285,8 +285,8 @@ func (lcd *largeChunkDecoder) nextByte() byte {
 func (lcd *largeChunkDecoder) ensureBytes(n int) {
 	if lcd.rem <= n {
 		rbuf := make([]byte, defaultChunkBufferSize)
-		copy(rbuf, lcd.rbuf[lcd.ptr:])
-		add := lcd.fillBuffer(rbuf[lcd.ptr:])
+		off := copy(rbuf, lcd.rbuf[lcd.ptr:lcd.ptr+lcd.rem])
+		add := lcd.fillBuffer(rbuf[off:])
 
 		lcd.ptr = 0
 		lcd.rem += add

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -101,6 +101,26 @@ func TestSmallBufferChunkData(t *testing.T) {
 	}
 }
 
+func TestEnsureBytes(t *testing.T) {
+	// the content here doesn't matter
+	r := strings.NewReader("0123456789")
+
+	lcd := largeChunkDecoder{
+		r, 0, 0,
+		3, 8189,
+		make([]byte, 8192),
+		bytes.NewBuffer(make([]byte, defaultStringBufferSize)),
+		nil,
+	}
+
+	lcd.ensureBytes(4)
+
+	// we expect the new remainder to be 3 + 10 (length of r)
+	if lcd.rem != 13 {
+		t.Fatalf("buffer was not refilled correctly")
+	}
+}
+
 func testDecodeOk(t *testing.T, s string) {
 	var rows [][]*string
 	if err := json.Unmarshal([]byte(s), &rows); err != nil {


### PR DESCRIPTION
### Description
We've known for a while that there's a bug here, but haven't had time or cause to address it. Today, a small window of opportunity opened up, so I pushed a fix through it 🙂 

Essentially the buffer copy logic in `ensureBytes` was just wrong. This fixes it to be right, and adds a test to expose the incorrect behavior. 

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
