### PR TITLE
Add new DescribeContext helper

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -47,14 +47,20 @@ func (sc *snowflakeConn) isDml(v int64) bool {
 
 func (sc *snowflakeConn) exec(
 	ctx context.Context,
-	query string, noResult bool, isInternal bool, parameters []driver.NamedValue) (*execResponse, error) {
+	query string,
+	noResult bool,
+	isInternal bool,
+	describeOnly bool,
+	parameters []driver.NamedValue,
+) (*execResponse, error) {
 	var err error
 	counter := atomic.AddUint64(&sc.SequeceCounter, 1) // query sequence counter
 
 	req := execRequest{
-		SQLText:    query,
-		AsyncExec:  noResult,
-		SequenceID: counter,
+		SQLText:      query,
+		AsyncExec:    noResult,
+		SequenceID:   counter,
+		DescribeOnly: describeOnly,
 	}
 	req.IsInternal = isInternal
 	tsmode := "TIMESTAMP_NTZ"
@@ -152,7 +158,7 @@ func (sc *snowflakeConn) BeginTx(ctx context.Context, opts driver.TxOptions) (dr
 	if sc.rest == nil {
 		return nil, driver.ErrBadConn
 	}
-	_, err := sc.exec(ctx, "BEGIN", false, false, nil)
+	_, err := sc.exec(ctx, "BEGIN", false, false, false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +177,7 @@ func (sc *snowflakeConn) Close() (err error) {
 
 	// ensure transaction is rollbacked
 	ctx := context.TODO()
-	_, err = sc.exec(ctx, "ROLLBACK", false, false, nil)
+	_, err = sc.exec(ctx, "ROLLBACK", false, false, false, nil)
 	if err != nil {
 		glog.V(2).Info(err)
 	}
@@ -188,7 +194,7 @@ func (sc *snowflakeConn) PrepareContext(ctx context.Context, query string) (driv
 	if sc.rest == nil {
 		return nil, driver.ErrBadConn
 	}
-	stmt := &snowflakeStmt{
+	stmt := &SnowflakeStmt{
 		sc:    sc,
 		query: query,
 	}
@@ -205,7 +211,7 @@ func (sc *snowflakeConn) ExecContext(ctx context.Context, query string, args []d
 		return nil, driver.ErrBadConn
 	}
 	// TODO: handle noResult and isInternal
-	data, err := sc.exec(ctx, query, false, false, args)
+	data, err := sc.exec(ctx, query, false, false, false, args)
 	if err != nil {
 		return nil, err
 	}
@@ -231,13 +237,28 @@ func (sc *snowflakeConn) ExecContext(ctx context.Context, query string, args []d
 	return driver.ResultNoRows, nil
 }
 
+func (sc *snowflakeConn) DescribeContext(ctx context.Context, query string, args []driver.NamedValue) ([]ColumnType, error) {
+	glog.V(2).Infof("Describe: %#v, %v", query, args)
+	if sc.rest == nil {
+		return nil, driver.ErrBadConn
+	}
+	// TODO: handle noResult and isInternal
+	data, err := sc.exec(ctx, query, false, false, true, args)
+	if err != nil {
+		glog.V(2).Infof("error: %v", err)
+		return nil, err
+	}
+
+	return rowTypesToColumnTypes(data.Data.RowType), err
+}
+
 func (sc *snowflakeConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	glog.V(2).Infof("Query: %#v, %v", query, args)
 	if sc.rest == nil {
 		return nil, driver.ErrBadConn
 	}
 	// TODO: handle noResult and isInternal
-	data, err := sc.exec(ctx, query, false, false, args)
+	data, err := sc.exec(ctx, query, false, false, false, args)
 	if err != nil {
 		glog.V(2).Infof("error: %v", err)
 		return nil, err
@@ -285,7 +306,7 @@ func (sc *snowflakeConn) Ping(ctx context.Context) error {
 		return driver.ErrBadConn
 	}
 	// TODO: handle noResult and isInternal
-	_, err := sc.exec(ctx, "SELECT 1", false, false, []driver.NamedValue{})
+	_, err := sc.exec(ctx, "SELECT 1", false, false, false, []driver.NamedValue{})
 	return err
 }
 

--- a/query.go
+++ b/query.go
@@ -12,12 +12,13 @@ type execBindParameter struct {
 }
 
 type execRequest struct {
-	SQLText    string                       `json:"sqlText"`
-	AsyncExec  bool                         `json:"asyncExec"`
-	SequenceID uint64                       `json:"sequenceId"`
-	IsInternal bool                         `json:"isInternal"`
-	Parameters map[string]string            `json:"parameters,omitempty"`
-	Bindings   map[string]execBindParameter `json:"bindings,omitempty"`
+	SQLText      string                       `json:"sqlText"`
+	AsyncExec    bool                         `json:"asyncExec"`
+	SequenceID   uint64                       `json:"sequenceId"`
+	IsInternal   bool                         `json:"isInternal"`
+	DescribeOnly bool                         `json:"describeOnly,omitempty"`
+	Parameters   map[string]string            `json:"parameters,omitempty"`
+	Bindings     map[string]execBindParameter `json:"bindings,omitempty"`
 }
 type execResponseRowType struct {
 	Name       string `json:"name"`

--- a/rows.go
+++ b/rows.go
@@ -128,7 +128,7 @@ func (rows *snowflakeRows) Columns() []string {
 func rowTypesToColumnTypes(rows []execResponseRowType) []ColumnType {
 	glog.V(3).Infoln("Rows.Columns")
 	ret := make([]ColumnType, len(rows))
-	for i, n := 0, len(rows); i < n; i++ {
+	for i, rt := range rows {
 		rt := rows[i]
 		ret[i] = ColumnType{
 			Name:     rt.Name,

--- a/rows.go
+++ b/rows.go
@@ -33,6 +33,12 @@ var (
 	maxChunkDownloaderErrorCounter = 5
 )
 
+type ColumnType struct {
+	Name     string
+	Type     string
+	Nullable bool
+}
+
 type snowflakeRows struct {
 	sc              *snowflakeConn
 	RowType         []execResponseRowType
@@ -115,6 +121,20 @@ func (rows *snowflakeRows) Columns() []string {
 	ret := make([]string, len(rows.RowType))
 	for i, n := 0, len(rows.RowType); i < n; i++ {
 		ret[i] = rows.RowType[i].Name
+	}
+	return ret
+}
+
+func rowTypesToColumnTypes(rows []execResponseRowType) []ColumnType {
+	glog.V(3).Infoln("Rows.Columns")
+	ret := make([]ColumnType, len(rows))
+	for i, n := 0, len(rows); i < n; i++ {
+		rt := rows[i]
+		ret[i] = ColumnType{
+			Name:     rt.Name,
+			Type:     strings.ToUpper(rt.Type),
+			Nullable: rt.Nullable,
+		}
 	}
 	return ret
 }

--- a/rows.go
+++ b/rows.go
@@ -129,7 +129,6 @@ func rowTypesToColumnTypes(rows []execResponseRowType) []ColumnType {
 	glog.V(3).Infoln("Rows.Columns")
 	ret := make([]ColumnType, len(rows))
 	for i, rt := range rows {
-		rt := rows[i]
 		ret[i] = ColumnType{
 			Name:     rt.Name,
 			Type:     strings.ToUpper(rt.Type),

--- a/statement.go
+++ b/statement.go
@@ -7,39 +7,44 @@ import (
 	"database/sql/driver"
 )
 
-type snowflakeStmt struct {
+type SnowflakeStmt struct {
 	sc    *snowflakeConn
 	query string
 }
 
-func (stmt *snowflakeStmt) Close() error {
+func (stmt *SnowflakeStmt) Close() error {
 	glog.V(2).Infoln("Stmt.Close")
 	// noop
 	return nil
 }
 
-func (stmt *snowflakeStmt) NumInput() int {
+func (stmt *SnowflakeStmt) NumInput() int {
 	glog.V(2).Infoln("Stmt.NumInput")
 	// Go Snowflake doesn't know the number of binding parameters.
 	return -1
 }
 
-func (stmt *snowflakeStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+func (stmt *SnowflakeStmt) DescribeContext(ctx context.Context, args ...driver.NamedValue) ([]ColumnType, error) {
+	glog.V(2).Infoln("Stmt.DescribeContext")
+	return stmt.sc.DescribeContext(ctx, stmt.query, args)
+}
+
+func (stmt *SnowflakeStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	glog.V(2).Infoln("Stmt.ExecContext")
 	return stmt.sc.ExecContext(ctx, stmt.query, args)
 }
 
-func (stmt *snowflakeStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+func (stmt *SnowflakeStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
 	glog.V(2).Infoln("Stmt.QueryContext")
 	return stmt.sc.QueryContext(ctx, stmt.query, args)
 }
 
-func (stmt *snowflakeStmt) Exec(args []driver.Value) (driver.Result, error) {
+func (stmt *SnowflakeStmt) Exec(args []driver.Value) (driver.Result, error) {
 	glog.V(2).Infoln("Stmt.Exec")
 	return stmt.sc.Exec(stmt.query, args)
 }
 
-func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
+func (stmt *SnowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 	glog.V(2).Infoln("Stmt.Query")
 	return stmt.sc.Query(stmt.query, args)
 }

--- a/statement.go
+++ b/statement.go
@@ -24,6 +24,8 @@ func (stmt *SnowflakeStmt) NumInput() int {
 	return -1
 }
 
+// NOTE this function isn't actually part of any of the `database/sql` interfaces. As such the SnowflakeStmt
+// struct must be public so that calling code can typecast and call the function.
 func (stmt *SnowflakeStmt) DescribeContext(ctx context.Context, args ...driver.NamedValue) ([]ColumnType, error) {
 	glog.V(2).Infoln("Stmt.DescribeContext")
 	return stmt.sc.DescribeContext(ctx, stmt.query, args)

--- a/transaction.go
+++ b/transaction.go
@@ -15,7 +15,7 @@ func (tx *snowflakeTx) Commit() (err error) {
 	if tx.sc == nil || tx.sc.rest == nil {
 		return driver.ErrBadConn
 	}
-	_, err = tx.sc.exec(context.TODO(), "COMMIT", false, false, nil)
+	_, err = tx.sc.exec(context.TODO(), "COMMIT", false, false, false, nil)
 	if err != nil {
 		return
 	}
@@ -27,7 +27,7 @@ func (tx *snowflakeTx) Rollback() (err error) {
 	if tx.sc == nil || tx.sc.rest == nil {
 		return driver.ErrBadConn
 	}
-	_, err = tx.sc.exec(context.TODO(), "ROLLBACK", false, false, nil)
+	_, err = tx.sc.exec(context.TODO(), "ROLLBACK", false, false, false, nil)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This PR adds a new DescribeContext helper as a fastpath to fetch the schema of a query. From what I could tell the JDBC driver uses this to construct prepared statements, so I figure we can use it here too. 