### PR TITLE
[SIG-7631] backport upstream fix for gcp-hosted sf accounts

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -35,6 +35,7 @@ var (
 	maxChunkDownloaderErrorCounter = 5
 )
 
+// ColumnType TODO
 type ColumnType struct {
 	Name     string
 	Type     string

--- a/rows.go
+++ b/rows.go
@@ -3,6 +3,8 @@
 package gosnowflake
 
 import (
+	"bufio"
+	"compress/gzip"
 	"context"
 	"database/sql/driver"
 	"encoding/json"
@@ -379,10 +381,11 @@ func downloadChunkHelper(ctx context.Context, scd *snowflakeChunkDownloader, idx
 	if err != nil {
 		return err
 	}
+	bufStream := bufio.NewReader(resp.Body)
 	defer resp.Body.Close()
 	glog.V(2).Infof("response returned chunk: %v, resp: %v", idx+1, resp)
 	if resp.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(bufStream)
 		if err != nil {
 			return err
 		}
@@ -397,14 +400,30 @@ func downloadChunkHelper(ctx context.Context, scd *snowflakeChunkDownloader, idx
 		}
 	}
 
-	return decodeChunkHelper(scd, idx, resp.Body)
+	return decodeChunkHelper(scd, idx, bufStream)
 }
 
-func decodeChunkHelper(scd *snowflakeChunkDownloader, idx int, body io.ReadCloser) (err error) {
+func decodeChunkHelper(scd *snowflakeChunkDownloader, idx int, bufStream *bufio.Reader) (err error) {
+	gzipMagic, err := bufStream.Peek(2)
+	if err != nil {
+		return err
+	}
 	start := time.Now()
+	var source io.Reader
+	if gzipMagic[0] == 0x1f && gzipMagic[1] == 0x8b {
+		// detects and uncompresses Gzip format data
+		bufStream0, err := gzip.NewReader(bufStream)
+		if err != nil {
+			return err
+		}
+		defer bufStream0.Close()
+		source = bufStream0
+	} else {
+		source = bufStream
+	}
 	st := &largeResultSetReader{
 		status: 0,
-		body:   body,
+		body:   source,
 	}
 	var respd [][]*string
 	if !CustomJSONDecoderEnabled {

--- a/statement.go
+++ b/statement.go
@@ -7,23 +7,27 @@ import (
 	"database/sql/driver"
 )
 
+// SnowflakeStmt TODO
 type SnowflakeStmt struct {
 	sc    *snowflakeConn
 	query string
 }
 
+// Close TODO
 func (stmt *SnowflakeStmt) Close() error {
 	glog.V(2).Infoln("Stmt.Close")
 	// noop
 	return nil
 }
 
+// NumInput TODO
 func (stmt *SnowflakeStmt) NumInput() int {
 	glog.V(2).Infoln("Stmt.NumInput")
 	// Go Snowflake doesn't know the number of binding parameters.
 	return -1
 }
 
+// DescribeContext TODO
 // NOTE this function isn't actually part of any of the `database/sql` interfaces. As such the SnowflakeStmt
 // struct must be public so that calling code can typecast and call the function.
 func (stmt *SnowflakeStmt) DescribeContext(ctx context.Context, args ...driver.NamedValue) ([]ColumnType, error) {
@@ -31,21 +35,25 @@ func (stmt *SnowflakeStmt) DescribeContext(ctx context.Context, args ...driver.N
 	return stmt.sc.DescribeContext(ctx, stmt.query, args)
 }
 
+// ExecContext TODO
 func (stmt *SnowflakeStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	glog.V(2).Infoln("Stmt.ExecContext")
 	return stmt.sc.ExecContext(ctx, stmt.query, args)
 }
 
+// QueryContext TODO
 func (stmt *SnowflakeStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
 	glog.V(2).Infoln("Stmt.QueryContext")
 	return stmt.sc.QueryContext(ctx, stmt.query, args)
 }
 
+// Exec TODO
 func (stmt *SnowflakeStmt) Exec(args []driver.Value) (driver.Result, error) {
 	glog.V(2).Infoln("Stmt.Exec")
 	return stmt.sc.Exec(stmt.query, args)
 }
 
+// Query TODO
 func (stmt *SnowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 	glog.V(2).Infoln("Stmt.Query")
 	return stmt.sc.Query(stmt.query, args)


### PR DESCRIPTION
Haven't tested with a GCP-hosted snowflake account since I don't yet have access to one, but the change doesn't seem to cause any problems with existing snowflake connections when running multiplex with the patched driver locally