### PR TITLE
[SIG-2992] ColumnType should include the scale

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -40,6 +40,7 @@ type ColumnType struct {
 	Name     string
 	Type     string
 	Nullable bool
+	Scale    int64
 }
 
 type snowflakeRows struct {
@@ -136,6 +137,7 @@ func rowTypesToColumnTypes(rows []execResponseRowType) []ColumnType {
 			Name:     rt.Name,
 			Type:     strings.ToUpper(rt.Type),
 			Nullable: rt.Nullable,
+			Scale:    rt.Scale,
 		}
 	}
 	return ret


### PR DESCRIPTION
### Description
Snowflake represents [all integer types](https://docs.snowflake.com/en/sql-reference/data-types-numeric.html#data-types-for-fixed-point-numbers) using 128-bit fixed-point numbers, but we'd like to differentiate between columns that are guaranteed to be integers and those that may have a non-zero fractional part.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
