### PR TITLE
add hook to fetch "monitoring" data

### DIFF
--- a/query.go
+++ b/query.go
@@ -71,3 +71,33 @@ type execResponse struct {
 	Code    string           `json:"code"`
 	Success bool             `json:"success"`
 }
+
+type monitoringResponse struct {
+	Data    monitoringResponseData `json:"data"`
+	Message string                 `json:"message"`
+	Code    string                 `json:"code"`
+	Success bool                   `json:"success"`
+}
+
+type monitoringResponseData struct {
+	Queries []QueryMonitoringData `json:"queries"`
+}
+
+type QueryMonitoringData struct {
+	Id                  string           `json:"id"`
+	Status              string           `json:"status"`
+	State               string           `json:"state"`
+	ClientSendTime      int64            `json:"clientSendTime"`
+	StartTime           int64            `json:"startTime"`
+	EndTime             int64            `json:"endTime"`
+	TotalDuration       int64            `json:"totalDuration"`
+	ClusterNumber       int              `json:"clusterNumber"`
+	WarehouseId         int              `json:"warehouseId"`
+	WarehouseName       string           `json:"warehouseName"`
+	WarehouseServerType string           `json:"warehouseServerType"`
+	QueryTag            string           `json:"queryTag"`
+	MajorVersionNumber  int              `json:"majorVersionNumber"`
+	MinorVersionNumber  int              `json:"minorVersionNumber"`
+	PatchVersionNumber  int              `json:"patchVersionNumber"`
+	Stats               map[string]int64 `json:"stats"`
+}

--- a/result.go
+++ b/result.go
@@ -8,12 +8,14 @@ package gosnowflake
 // both implement this interface.
 type SnowflakeResult interface {
 	QueryID() string
+	Monitoring() *QueryMonitoringData
 }
 
 type snowflakeResult struct {
 	affectedRows int64
 	insertID     int64 // Snowflake doesn't support last insert id
 	queryID      string
+	monitoring   *QueryMonitoringData
 }
 
 func (res *snowflakeResult) LastInsertId() (int64, error) {
@@ -26,4 +28,7 @@ func (res *snowflakeResult) RowsAffected() (int64, error) {
 
 func (res *snowflakeResult) QueryID() string {
 	return res.queryID
+}
+func (res *snowflakeResult) Monitoring() *QueryMonitoringData {
+	return res.monitoring
 }

--- a/rows.go
+++ b/rows.go
@@ -48,6 +48,7 @@ type snowflakeRows struct {
 	RowType         []execResponseRowType
 	ChunkDownloader *snowflakeChunkDownloader
 	queryID         string
+	monitoring      *QueryMonitoringData
 }
 
 func (rows *snowflakeRows) Close() (err error) {
@@ -145,6 +146,9 @@ func rowTypesToColumnTypes(rows []execResponseRowType) []ColumnType {
 
 func (rows *snowflakeRows) QueryID() string {
 	return rows.queryID
+}
+func (rows *snowflakeRows) Monitoring() *QueryMonitoringData {
+	return rows.monitoring
 }
 
 func (rows *snowflakeRows) ColumnTypeScanType(index int) reflect.Type {


### PR DESCRIPTION
### Description
This adds a mechanism to surface "monitoring" data for a query, without requiring the caller to issue a request to the QUERY_HISTORY table. It also adds a knob that we can tune to determine when this fetching kicks in. We use the same mechanism as `QueryID()` to fetch this data. It's not great, but it reuses the existing pattern.