### PR TITLE
Add get and set query tag helpers

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -85,17 +85,17 @@ func (sc *snowflakeConn) exec(
 		AsyncExec:    noResult,
 		SequenceID:   counter,
 		DescribeOnly: describeOnly,
-    Parameters: make(map[string]string),
+      Parameters: make(map[string]string),
 	}
 	req.IsInternal = isInternal
-  queryTag := sc.GetContextQueryTag(ctx)
-  if queryTag != nil {
-    jsonQueryTag, err := json.Marshal(queryTag)
-    if err != nil {
-      return nil, err
+    queryTag := sc.GetContextQueryTag(ctx)
+    if queryTag != nil {
+        jsonQueryTag, err := json.Marshal(queryTag)
+        if err != nil {
+            return nil, err
+        }
+        req.Parameters["QUERY_TAG"] = string(jsonQueryTag)
     }
-    req.Parameters["QUERY_TAG"] = string(jsonQueryTag)
-  }
 	tsmode := "TIMESTAMP_NTZ"
 	idx := 1
 	if len(parameters) > 0 {

--- a/connection.go
+++ b/connection.go
@@ -94,10 +94,7 @@ func (sc *snowflakeConn) exec(
 		if err != nil {
 			return nil, err
 		}
-		//req.Parameters["QUERY_TAG"] = string(jsonQueryTag)
 		req.Parameters["QUERY_TAG"] = string(jsonQueryTag)
-	} else {
-		req.Parameters["QUERY_TAG"] = "something is wrong"
 	}
 	tsmode := "TIMESTAMP_NTZ"
 	idx := 1


### PR DESCRIPTION
### Description
[SIG-7344] These helper functions will be used in multiplex to add query tags.
![image](https://user-images.githubusercontent.com/16244236/116477724-db3cf080-a831-11eb-9e9a-24eefa496e90.png)

Verified by running integration tests and seeing the request ID and email attached.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
