### PR TITLE
Fix arrowToValue handling of timestamp_ltz at non-nanosecond scales

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -454,9 +454,7 @@ func arrowToValue(destcol *[]snowflakeValue, srcColumnMeta execResponseRowType, 
 		} else {
 			for i, t := range array.NewInt64Data(data).Int64Values() {
 				if !srcValue.IsNull(i) {
-					q := t / int64(math.Pow10(int(srcColumnMeta.Scale)))
-					r := t % int64(math.Pow10(int(srcColumnMeta.Scale)))
-					(*destcol)[i] = time.Unix(q, r)
+					(*destcol)[i] = time.Unix(0, t*int64(math.Pow10(9-int(srcColumnMeta.Scale))))
 				}
 			}
 		}

--- a/converter_test.go
+++ b/converter_test.go
@@ -439,6 +439,26 @@ func TestArrowToValue(t *testing.T) {
 			},
 		},
 		{
+			logical: "timestamp_ntz",
+			values:  []time.Time{time.Now(), localTime},
+			rowType: execResponseRowType{Scale: 3},
+			builder: array.NewInt64Builder(pool),
+			append: func(b array.Builder, vs interface{}) {
+				for _, t := range vs.([]time.Time) {
+					b.(*array.Int64Builder).Append(t.UnixNano() / 1000000)
+				}
+			},
+			compare: func(src interface{}, dst []snowflakeValue) int {
+				srcvs := src.([]time.Time)
+				for i := range srcvs {
+					if srcvs[i].UnixNano()/1000000 != dst[i].(time.Time).UnixNano()/1000000 {
+						return i
+					}
+				}
+				return -1
+			},
+		},
+		{
 			logical: "timestamp_ltz",
 			values:  []time.Time{time.Now(), localTime},
 			rowType: execResponseRowType{Scale: 9},
@@ -452,6 +472,26 @@ func TestArrowToValue(t *testing.T) {
 				srcvs := src.([]time.Time)
 				for i := range srcvs {
 					if srcvs[i].UnixNano() != dst[i].(time.Time).UnixNano() {
+						return i
+					}
+				}
+				return -1
+			},
+		},
+		{
+			logical: "timestamp_ltz",
+			values:  []time.Time{time.Now(), localTime},
+			rowType: execResponseRowType{Scale: 3},
+			builder: array.NewInt64Builder(pool),
+			append: func(b array.Builder, vs interface{}) {
+				for _, t := range vs.([]time.Time) {
+					b.(*array.Int64Builder).Append(t.UnixNano() / 1000000)
+				}
+			},
+			compare: func(src interface{}, dst []snowflakeValue) int {
+				srcvs := src.([]time.Time)
+				for i := range srcvs {
+					if srcvs[i].UnixNano()/1000000 != dst[i].(time.Time).UnixNano()/1000000 {
 						return i
 					}
 				}


### PR DESCRIPTION
### Description
When converting arrow results with a scale other than nanoseconds (i.e. 10e-9) in their metadata, timestamp_ltz results would still be incorrectly interpreted as nanoseconds. This change brings timestamp_ltz in line with the correct behavior, which was already implemented for timestamp_ntz, and adds tests for both.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
