### PR TITLE
[monitoring] fetch the query graph for slow queries

### DIFF
--- a/query.go
+++ b/query.go
@@ -187,7 +187,7 @@ type ExecutionGraphData struct {
 
 type ExecutionGraphNode struct {
 	Id         int                      `json:"id"`
-	LogicalId  string                   `json:"logicalId"`
+	LogicalId  int                      `json:"logicalId"`
 	Name       string                   `json:"name"`
 	Title      string                   `json:"title"`
 	Statistics ExecutionGraphStatistics `json:"statistics"`
@@ -196,10 +196,10 @@ type ExecutionGraphNode struct {
 }
 
 type ExecutionGraphEdge struct {
-	Id   int `json:"id"`
-	Src  int `json:"src"`
-	Dst  int `json:"dst"`
-	Rows int `json:"rows"`
+	Id   string `json:"id"`
+	Src  int    `json:"src"`
+	Dst  int    `json:"dst"`
+	Rows int    `json:"rows"`
 }
 
 type ExecutionGraphGlobals struct {
@@ -211,13 +211,13 @@ type ExecutionGraphGlobals struct {
 type ExecutionGraphStatistics map[string][]ExecutionGraphStatistic
 
 type ExecutionGraphStatistic struct {
-	Name  string `json:"name"`
-	Value int    `json:"value"`
-	Unit  string `json:"unit"`
+	Name  string  `json:"name"`
+	Value float64 `json:"value"`
+	Unit  string  `json:"unit"`
 }
 
 type ExecutionGraphWait struct {
 	Name       string  `json:"name"`
-	Value      int     `json:"value"`
+	Value      float64 `json:"value"`
 	Percentage float64 `json:"percentage"`
 }

--- a/query.go
+++ b/query.go
@@ -186,7 +186,7 @@ type ExecutionGraphData struct {
 }
 
 type ExecutionGraphNode struct {
-	Id         string                   `json:"id"`
+	Id         int                      `json:"id"`
 	LogicalId  string                   `json:"logicalId"`
 	Name       string                   `json:"name"`
 	Title      string                   `json:"title"`

--- a/query.go
+++ b/query.go
@@ -159,3 +159,65 @@ type monitoringResponse struct {
 	Code    string `json:"code"`
 	Success bool   `json:"success"`
 }
+
+type queryGraphResponse struct {
+	Data    QueryGraphData `json:"data"`
+	Message string         `json:"message"`
+	Code    string         `json:"code"`
+	Success bool           `json:"success"`
+}
+
+type QueryGraphData struct {
+	Steps []QueryGraphStep `json:"steps"`
+}
+
+type QueryGraphStep struct {
+	Step           int                `json:"step"`
+	Description    string             `json:"description"`
+	TimeInMs       int                `json:"timeInMs"`
+	State          string             `json:"state"`
+	ExecutionGraph ExecutionGraphData `json:"graphData"`
+}
+
+type ExecutionGraphData struct {
+	Nodes  []ExecutionGraphNode  `json:"nodes"`
+	Edges  []ExecutionGraphEdge  `json:"edges"`
+	Global ExecutionGraphGlobals `json:"global"`
+}
+
+type ExecutionGraphNode struct {
+	Id         string                   `json:"id"`
+	LogicalId  string                   `json:"logicalId"`
+	Name       string                   `json:"name"`
+	Title      string                   `json:"title"`
+	Statistics ExecutionGraphStatistics `json:"statistics"`
+	Waits      []ExecutionGraphWait     `json:"waits"`
+	TotalStats ExecutionGraphWait       `json:"totalStats"`
+}
+
+type ExecutionGraphEdge struct {
+	Id   int `json:"id"`
+	Src  int `json:"src"`
+	Dst  int `json:"dst"`
+	Rows int `json:"rows"`
+}
+
+type ExecutionGraphGlobals struct {
+	Statistics ExecutionGraphStatistics `json:"statistics"`
+	Waits      []ExecutionGraphWait     `json:"waits"`
+	TotalStats ExecutionGraphWait       `json:"totalStats"`
+}
+
+type ExecutionGraphStatistics map[string][]ExecutionGraphStatistic
+
+type ExecutionGraphStatistic struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+	Unit  string `json:"unit"`
+}
+
+type ExecutionGraphWait struct {
+	Name       string  `json:"name"`
+	Value      int     `json:"value"`
+	Percentage float64 `json:"percentage"`
+}

--- a/result.go
+++ b/result.go
@@ -30,6 +30,7 @@ type snowflakeResult struct {
 	err          error
 	errChannel   chan error
 	monitoring   *QueryMonitoringData
+	queryGraph   *QueryGraphData
 }
 
 func (res *snowflakeResult) LastInsertId() (int64, error) {
@@ -72,4 +73,7 @@ func (res *snowflakeResult) waitForAsyncExecStatus() error {
 
 func (res *snowflakeResult) Monitoring() *QueryMonitoringData {
 	return res.monitoring
+}
+func (res *snowflakeResult) QueryGraph() *QueryGraphData {
+	return res.queryGraph
 }

--- a/rows.go
+++ b/rows.go
@@ -36,6 +36,7 @@ type snowflakeRows struct {
 	err                 error
 	errChannel          chan error
 	monitoring          *QueryMonitoringData
+	queryGraph          *QueryGraphData
 }
 
 type snowflakeValue interface{}
@@ -143,6 +144,10 @@ func (rows *snowflakeRows) GetQueryID() string {
 
 func (rows *snowflakeRows) Monitoring() *QueryMonitoringData {
 	return rows.monitoring
+}
+
+func (res *snowflakeRows) QueryGraph() *QueryGraphData {
+	return res.queryGraph
 }
 
 func (rows *snowflakeRows) GetStatus() queryStatus {


### PR DESCRIPTION
This PR adds a method to fetch the QueryGraph for slow queries. This allows us to get a detailed look at the query execution plan, in order to diagnose performance bottlenecks for customers. 