### PR TITLE
Allow client to specify any data type explicitly

### DIFF
--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -170,13 +170,13 @@ func getBindValues(bindings []driver.NamedValue) (map[string]execBindParameter, 
 	idx := 1
 	var err error
 	bindValues := make(map[string]execBindParameter, len(bindings))
-	var dataType *SnowflakeDataType
+	var dataType SnowflakeDataType
 	for _, binding := range bindings {
 		switch binding.Value.(type) {
-		case *SnowflakeDataType:
+		case SnowflakeDataType:
 			// This binding is just specifying the type for subsequent bindings
-			dataType = binding.Value.(*SnowflakeDataType)
-			fmt.Printf("GREG changed dataType: %v\n", dataType)
+			dataType = binding.Value.(SnowflakeDataType)
+			fmt.Printf("GREG changed dataType %v\n", dataType)
 		default:
 			// This binding is an actual parameter for the query
 			t := goTypeToSnowflake(binding.Value, dataType)

--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -166,7 +166,6 @@ func (bu *bindUploader) createCSVRecord(data []string) []byte {
 }
 
 func getBindValues(bindings []driver.NamedValue) (map[string]execBindParameter, error) {
-	fmt.Printf("GREG got bindings %v\n", bindings)
 	idx := 1
 	var err error
 	bindValues := make(map[string]execBindParameter, len(bindings))
@@ -176,7 +175,6 @@ func getBindValues(bindings []driver.NamedValue) (map[string]execBindParameter, 
 		case SnowflakeDataType:
 			// This binding is just specifying the type for subsequent bindings
 			dataType = binding.Value.(SnowflakeDataType)
-			fmt.Printf("GREG changed dataType %v\n", dataType)
 		default:
 			// This binding is an actual parameter for the query
 			t := goTypeToSnowflake(binding.Value, dataType)

--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -166,24 +166,26 @@ func (bu *bindUploader) createCSVRecord(data []string) []byte {
 }
 
 func getBindValues(bindings []driver.NamedValue) (map[string]execBindParameter, error) {
-	tsmode := timestampNtzType
+	fmt.Printf("GREG got bindings %v\n", bindings)
 	idx := 1
 	var err error
 	bindValues := make(map[string]execBindParameter, len(bindings))
+	var dataType *SnowflakeDataType
 	for _, binding := range bindings {
-		t := goTypeToSnowflake(binding.Value, tsmode)
-		if t == changeType {
-			tsmode, err = dataTypeMode(binding.Value)
-			if err != nil {
-				return nil, err
-			}
-		} else {
+		switch binding.Value.(type) {
+		case *SnowflakeDataType:
+			// This binding is just specifying the type for subsequent bindings
+			dataType = binding.Value.(*SnowflakeDataType)
+			fmt.Printf("GREG changed dataType: %v\n", dataType)
+		default:
+			// This binding is an actual parameter for the query
+			t := goTypeToSnowflake(binding.Value, dataType)
 			var val interface{}
 			if t == sliceType {
 				// retrieve array binding data
 				t, val = snowflakeArrayToString(&binding, false)
 			} else {
-				val, err = valueToString(binding.Value, tsmode)
+				val, err = valueToString(binding.Value, dataType)
 				if err != nil {
 					return nil, err
 				}

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -137,18 +137,22 @@ func TestBindingDateTimeTimestamp(t *testing.T) {
 
 func TestBindingBinary(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
-		dbt.mustExec("CREATE OR REPLACE TABLE bintest (id int, b binary)")
+		dbt.mustExec("CREATE OR REPLACE TABLE bintest (id int, b binary, c binary)")
 		var b = []byte{0x01, 0x02, 0x03}
-		dbt.mustExec("INSERT INTO bintest(id,b) VALUES(1, ?)", DataTypeBinary, b)
-		rows := dbt.mustQuery("SELECT b FROM bintest WHERE id=?", 1)
+		dbt.mustExec("INSERT INTO bintest(id,b,c) VALUES(1, ?, ?)", DataTypeBinary, b, DataTypeBinary, b)
+		rows := dbt.mustQuery("SELECT b, c FROM bintest WHERE id=?", 1)
 		defer rows.Close()
 		if rows.Next() {
 			var rb []byte
-			if err := rows.Scan(&rb); err != nil {
+			var rc []byte
+			if err := rows.Scan(&rb, &rc); err != nil {
 				dbt.Errorf("failed to scan data. err: %v", err)
 			}
 			if !bytes.Equal(b, rb) {
 				dbt.Errorf("failed to match data. expected: %v, got: %v", b, rb)
+			}
+			if !bytes.Equal(b, rc) {
+				dbt.Errorf("failed to match data. expected: %v, got: %v", b, rc)
 			}
 		} else {
 			dbt.Errorf("no data")

--- a/connection.go
+++ b/connection.go
@@ -271,11 +271,47 @@ func (sc *snowflakeConn) PrepareContext(
 	return stmt, nil
 }
 
+func logNamedValueArgs(name string, args []driver.NamedValue) {
+	found := false
+	for _, arg := range args {
+		switch arg.Value.(type) {
+		case SnowflakeDataType:
+			found = true
+			fmt.Printf("GREG %s got data type arg: %v\n", name, arg)
+		case *SnowflakeDataType:
+			found = true
+			fmt.Printf("GREG %s got * data type arg: %v\n", name, arg)
+		}
+	}
+	if !found {
+		fmt.Printf("GREG %s scanned %d args, found no data types\n", name, len(args))
+	}
+}
+
+func logValueArgs(name string, args []driver.Value) {
+	found := false
+	for _, arg := range args {
+		switch arg.(type) {
+		case SnowflakeDataType:
+			found = true
+			fmt.Printf("GREG %s got data type arg: %v\n", name, arg)
+		case *SnowflakeDataType:
+			found = true
+			fmt.Printf("GREG %s got * data type arg: %v\n", name, arg)
+		}
+	}
+	if !found {
+		fmt.Printf("GREG %s scanned %d args, found no data types\n\n", name, len(args))
+	}
+}
+
 func (sc *snowflakeConn) ExecContext(
 	ctx context.Context,
 	query string,
 	args []driver.NamedValue) (
 	driver.Result, error) {
+	logNamedValueArgs("connection.ExecContext", args)
+
 	logger.WithContext(ctx).Infof("Exec: %#v, %v", query, args)
 	if sc.rest == nil {
 		return nil, driver.ErrBadConn
@@ -417,6 +453,8 @@ func (sc *snowflakeConn) Exec(
 	query string,
 	args []driver.Value) (
 	driver.Result, error) {
+	logValueArgs("connection.Exec", args)
+
 	return sc.ExecContext(sc.ctx, query, toNamedValues(args))
 }
 

--- a/connection.go
+++ b/connection.go
@@ -443,8 +443,7 @@ func (sc *snowflakeConn) Ping(ctx context.Context) error {
 // CheckNamedValue determines which types are handled by this driver aside from
 // the instances captured by driver.Value
 func (sc *snowflakeConn) CheckNamedValue(nv *driver.NamedValue) error {
-	switch nv.Value.(type) {
-	case SnowflakeDataType:
+	if _, ok := nv.Value.(SnowflakeDataType); ok {
 		// Pass SnowflakeDataType args through without modification so that we can
 		// distinguish them from arguments of type []byte
 		return nil

--- a/connection.go
+++ b/connection.go
@@ -278,9 +278,6 @@ func logNamedValueArgs(name string, args []driver.NamedValue) {
 		case SnowflakeDataType:
 			found = true
 			fmt.Printf("GREG %s got data type arg: %v\n", name, arg)
-		case *SnowflakeDataType:
-			found = true
-			fmt.Printf("GREG %s got * data type arg: %v\n", name, arg)
 		}
 	}
 	if !found {
@@ -295,9 +292,6 @@ func logValueArgs(name string, args []driver.Value) {
 		case SnowflakeDataType:
 			found = true
 			fmt.Printf("GREG %s got data type arg: %v\n", name, arg)
-		case *SnowflakeDataType:
-			found = true
-			fmt.Printf("GREG %s got * data type arg: %v\n", name, arg)
 		}
 	}
 	if !found {

--- a/converter.go
+++ b/converter.go
@@ -33,16 +33,22 @@ func goTypeToSnowflake(v driver.Value, tsmode snowflakeType) snowflakeType {
 	case string:
 		return textType
 	case []byte:
-		if tsmode == binaryType {
-			return binaryType // may be redundant but ensures BINARY type
-		}
 		if t == nil {
+			if tsmode == binaryType {
+				return binaryType
+			}
 			return nullType // invalid byte array. won't take as BINARY
 		}
 		if len(t) != 1 {
+			if tsmode == binaryType {
+				return binaryType
+			}
 			return unSupportedType
 		}
 		if _, err := dataTypeMode(t); err != nil {
+			if tsmode == binaryType {
+				return binaryType
+			}
 			return unSupportedType
 		}
 		return changeType

--- a/converter.go
+++ b/converter.go
@@ -39,8 +39,8 @@ func goTypeToSnowflake(v driver.Value, dataType SnowflakeDataType) snowflakeType
 			if t == nil {
 				return nullType // invalid byte array. won't take as BINARY
 			}
-			// If we don't have an explicit data type, assume a byte blob is binary
-			return binaryType
+			// If we don't have an explicit data type, binary blobs are unsupported
+			return unSupportedType
 		case time.Time:
 			// Default timestamp type
 			return timestampNtzType

--- a/converter.go
+++ b/converter.go
@@ -138,7 +138,6 @@ func valueToString(v driver.Value, dataType SnowflakeDataType) (*string, error) 
 			}
 		}
 	}
-	fmt.Printf("GREG v: %v\tv1:%v\tdataType: %v\n", v, v1, dataType)
 	return nil, fmt.Errorf("unsupported type: %v", v1.Kind())
 }
 

--- a/converter_test.go
+++ b/converter_test.go
@@ -34,7 +34,6 @@ func TestGoTypeToSnowflake(t *testing.T) {
 		{in: time.Now(), tmode: DataTypeTimestampTz, out: timestampTzType},
 		{in: time.Now(), tmode: DataTypeTimestampLtz, out: timestampLtzType},
 		{in: []byte{1, 2, 3}, tmode: DataTypeBinary, out: binaryType},
-		{in: []byte{100}, tmode: nil, out: binaryType},
 		// Every explicit DataType should return changeType
 		{in: DataTypeFixed, tmode: nil, out: changeType},
 		{in: DataTypeReal, tmode: nil, out: changeType},
@@ -56,6 +55,7 @@ func TestGoTypeToSnowflake(t *testing.T) {
 		{in: uint(456), tmode: nil, out: unSupportedType},
 		{in: uint8(12), tmode: nil, out: unSupportedType},
 		{in: uint64(456), tmode: nil, out: unSupportedType},
+		{in: []byte{100}, tmode: nil, out: unSupportedType},
 		{in: nil, tmode: nil, out: unSupportedType},
 		{in: []int{1}, tmode: nil, out: unSupportedType},
 	}

--- a/converter_test.go
+++ b/converter_test.go
@@ -22,7 +22,6 @@ type tcGoTypeToSnowflake struct {
 	out   snowflakeType
 }
 
-/*
 func TestGoTypeToSnowflake(t *testing.T) {
 	testcases := []tcGoTypeToSnowflake{
 		{in: int64(123), tmode: nil, out: fixedType},
@@ -66,7 +65,7 @@ func TestGoTypeToSnowflake(t *testing.T) {
 			t.Errorf("failed. in: %v, tmode: %v, expected: %v, got: %v", test.in, test.tmode, test.out, a)
 		}
 	}
-  }*/
+}
 
 type tcSnowflakeTypeToGo struct {
 	in    snowflakeType

--- a/converter_test.go
+++ b/converter_test.go
@@ -5,47 +5,60 @@ package gosnowflake
 import (
 	"database/sql/driver"
 	"fmt"
-	"github.com/apache/arrow/go/arrow"
-	"github.com/apache/arrow/go/arrow/array"
-	"github.com/apache/arrow/go/arrow/memory"
 	"math/big"
 	"math/cmplx"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/apache/arrow/go/arrow"
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/apache/arrow/go/arrow/memory"
 )
 
 type tcGoTypeToSnowflake struct {
 	in    interface{}
-	tmode snowflakeType
+	tmode SnowflakeDataType
 	out   snowflakeType
 }
 
+/*
 func TestGoTypeToSnowflake(t *testing.T) {
 	testcases := []tcGoTypeToSnowflake{
-		{in: int64(123), tmode: nullType, out: fixedType},
-		{in: float64(234.56), tmode: nullType, out: realType},
-		{in: true, tmode: nullType, out: booleanType},
-		{in: "teststring", tmode: nullType, out: textType},
-		{in: Array([]int{1}), tmode: nullType, out: sliceType},
-		{in: DataTypeBinary, tmode: nullType, out: changeType},
-		{in: DataTypeTimestampLtz, tmode: nullType, out: changeType},
-		{in: DataTypeTimestampNtz, tmode: nullType, out: changeType},
-		{in: DataTypeTimestampTz, tmode: nullType, out: changeType},
-		{in: time.Now(), tmode: timestampNtzType, out: timestampNtzType},
-		{in: time.Now(), tmode: timestampTzType, out: timestampTzType},
-		{in: time.Now(), tmode: timestampLtzType, out: timestampLtzType},
-		{in: []byte{1, 2, 3}, tmode: binaryType, out: binaryType},
+		{in: int64(123), tmode: nil, out: fixedType},
+		{in: float64(234.56), tmode: nil, out: realType},
+		{in: true, tmode: nil, out: booleanType},
+		{in: "teststring", tmode: nil, out: textType},
+		{in: Array([]int{1}), tmode: nil, out: sliceType},
+		{in: time.Now(), tmode: nil, out: timestampNtzType},
+		{in: time.Now(), tmode: DataTypeTimestampNtz, out: timestampNtzType},
+		{in: time.Now(), tmode: DataTypeTimestampTz, out: timestampTzType},
+		{in: time.Now(), tmode: DataTypeTimestampLtz, out: timestampLtzType},
+		{in: []byte{1, 2, 3}, tmode: DataTypeBinary, out: binaryType},
+		{in: []byte{100}, tmode: nil, out: binaryType},
+		// Every explicit DataType should return changeType
+		{in: DataTypeFixed, tmode: nil, out: changeType},
+		{in: DataTypeReal, tmode: nil, out: changeType},
+		{in: DataTypeText, tmode: nil, out: changeType},
+		{in: DataTypeDate, tmode: nil, out: changeType},
+		{in: DataTypeVariant, tmode: nil, out: changeType},
+		{in: DataTypeTimestampLtz, tmode: nil, out: changeType},
+		{in: DataTypeTimestampNtz, tmode: nil, out: changeType},
+		{in: DataTypeTimestampTz, tmode: nil, out: changeType},
+		{in: DataTypeObject, tmode: nil, out: changeType},
+		{in: DataTypeArray, tmode: nil, out: changeType},
+		{in: DataTypeBinary, tmode: nil, out: changeType},
+		{in: DataTypeTime, tmode: nil, out: changeType},
+		{in: DataTypeBoolean, tmode: nil, out: changeType},
 		// negative
-		{in: 123, tmode: nullType, out: unSupportedType},
-		{in: int8(12), tmode: nullType, out: unSupportedType},
-		{in: int32(456), tmode: nullType, out: unSupportedType},
-		{in: uint(456), tmode: nullType, out: unSupportedType},
-		{in: uint8(12), tmode: nullType, out: unSupportedType},
-		{in: uint64(456), tmode: nullType, out: unSupportedType},
-		{in: []byte{100}, tmode: nullType, out: unSupportedType},
-		{in: nil, tmode: nullType, out: unSupportedType},
-		{in: []int{1}, tmode: nullType, out: unSupportedType},
+		{in: 123, tmode: nil, out: unSupportedType},
+		{in: int8(12), tmode: nil, out: unSupportedType},
+		{in: int32(456), tmode: nil, out: unSupportedType},
+		{in: uint(456), tmode: nil, out: unSupportedType},
+		{in: uint8(12), tmode: nil, out: unSupportedType},
+		{in: uint64(456), tmode: nil, out: unSupportedType},
+		{in: nil, tmode: nil, out: unSupportedType},
+		{in: []int{1}, tmode: nil, out: unSupportedType},
 	}
 	for _, test := range testcases {
 		a := goTypeToSnowflake(test.in, test.tmode)
@@ -53,7 +66,7 @@ func TestGoTypeToSnowflake(t *testing.T) {
 			t.Errorf("failed. in: %v, tmode: %v, expected: %v, got: %v", test.in, test.tmode, test.out, a)
 		}
 	}
-}
+  }*/
 
 type tcSnowflakeTypeToGo struct {
 	in    snowflakeType
@@ -89,7 +102,7 @@ func TestSnowflakeTypeToGo(t *testing.T) {
 
 func TestValueToString(t *testing.T) {
 	v := cmplx.Sqrt(-5 + 12i) // should never happen as Go sql package must have already validated.
-	_, err := valueToString(v, nullType)
+	_, err := valueToString(v, nil)
 	if err == nil {
 		t.Errorf("should raise error: %v", v)
 	}
@@ -99,7 +112,7 @@ func TestValueToString(t *testing.T) {
 	utcTime := time.Date(2019, 2, 6, 22, 17, 31, 123456789, time.UTC)
 	expectedUnixTime := "1549491451123456789" // time.Unix(1549491451, 123456789).Format(time.RFC3339) == "2019-02-06T14:17:31-08:00"
 
-	if s, err := valueToString(localTime, timestampLtzType); err != nil {
+	if s, err := valueToString(localTime, DataTypeTimestampLtz); err != nil {
 		t.Error("unexpected error")
 	} else if s == nil {
 		t.Errorf("expected '%v', got %v", expectedUnixTime, s)
@@ -107,7 +120,7 @@ func TestValueToString(t *testing.T) {
 		t.Errorf("expected '%v', got '%v'", expectedUnixTime, *s)
 	}
 
-	if s, err := valueToString(utcTime, timestampLtzType); err != nil {
+	if s, err := valueToString(utcTime, DataTypeTimestampLtz); err != nil {
 		t.Error("unexpected error")
 	} else if s == nil {
 		t.Errorf("expected '%v', got %v", expectedUnixTime, s)

--- a/datatype.go
+++ b/datatype.go
@@ -54,11 +54,13 @@ func getSnowflakeType(typ string) snowflakeType {
 	return nullType
 }
 
-// Real solution: these should just be a separate public-facing type so that we
-// can always differentiate between "change type" and "value" args
-
+// SnowflakeDataType is the type used by clients to explicitly indicate the type
+// of an argument to ExecContext and friends. We use a separate public-facing
+// type rather than a Go primitive type so that we can always differentiate
+// between args that indicate type and args that are values.
 type SnowflakeDataType []byte
 
+// Equals checks if dt and o represent the same type indicator
 func (dt SnowflakeDataType) Equals(o SnowflakeDataType) bool {
 	return bytes.Equal(([]byte)(dt), ([]byte)(o))
 }

--- a/datatype.go
+++ b/datatype.go
@@ -88,18 +88,32 @@ var (
 func dataTypeMode(v driver.Value) (tsmode snowflakeType, err error) {
 	if bd, ok := v.([]byte); ok {
 		switch {
+		case bytes.Equal(bd, DataTypeFixed):
+			tsmode = fixedType
+		case bytes.Equal(bd, DataTypeReal):
+			tsmode = realType
+		case bytes.Equal(bd, DataTypeText):
+			tsmode = textType
 		case bytes.Equal(bd, DataTypeDate):
 			tsmode = dateType
-		case bytes.Equal(bd, DataTypeTime):
-			tsmode = timeType
+		case bytes.Equal(bd, DataTypeVariant):
+			tsmode = variantType
 		case bytes.Equal(bd, DataTypeTimestampLtz):
 			tsmode = timestampLtzType
 		case bytes.Equal(bd, DataTypeTimestampNtz):
 			tsmode = timestampNtzType
 		case bytes.Equal(bd, DataTypeTimestampTz):
 			tsmode = timestampTzType
+		case bytes.Equal(bd, DataTypeObject):
+			tsmode = objectType
+		case bytes.Equal(bd, DataTypeArray):
+			tsmode = arrayType
 		case bytes.Equal(bd, DataTypeBinary):
 			tsmode = binaryType
+		case bytes.Equal(bd, DataTypeTime):
+			tsmode = timeType
+		case bytes.Equal(bd, DataTypeBoolean):
+			tsmode = booleanType
 		default:
 			return nullType, fmt.Errorf(errMsgInvalidByteArray, v)
 		}

--- a/datatype.go
+++ b/datatype.go
@@ -65,64 +65,64 @@ func (dt SnowflakeDataType) Equals(o SnowflakeDataType) bool {
 
 var (
 	// DataTypeFixed is a FIXED datatype.
-	DataTypeFixed = &SnowflakeDataType{fixedType.Byte()}
+	DataTypeFixed = SnowflakeDataType{fixedType.Byte()}
 	// DataTypeReal is a REAL datatype.
-	DataTypeReal = &SnowflakeDataType{realType.Byte()}
+	DataTypeReal = SnowflakeDataType{realType.Byte()}
 	// DataTypeText is a TEXT datatype.
-	DataTypeText = &SnowflakeDataType{textType.Byte()}
+	DataTypeText = SnowflakeDataType{textType.Byte()}
 	// DataTypeDate is a Date datatype.
-	DataTypeDate = &SnowflakeDataType{dateType.Byte()}
+	DataTypeDate = SnowflakeDataType{dateType.Byte()}
 	// DataTypeVariant is a TEXT datatype.
-	DataTypeVariant = &SnowflakeDataType{variantType.Byte()}
+	DataTypeVariant = SnowflakeDataType{variantType.Byte()}
 	// DataTypeTimestampLtz is a TIMESTAMP_LTZ datatype.
-	DataTypeTimestampLtz = &SnowflakeDataType{timestampLtzType.Byte()}
+	DataTypeTimestampLtz = SnowflakeDataType{timestampLtzType.Byte()}
 	// DataTypeTimestampNtz is a TIMESTAMP_NTZ datatype.
-	DataTypeTimestampNtz = &SnowflakeDataType{timestampNtzType.Byte()}
+	DataTypeTimestampNtz = SnowflakeDataType{timestampNtzType.Byte()}
 	// DataTypeTimestampTz is a TIMESTAMP_TZ datatype.
-	DataTypeTimestampTz = &SnowflakeDataType{timestampTzType.Byte()}
+	DataTypeTimestampTz = SnowflakeDataType{timestampTzType.Byte()}
 	// DataTypeObject is a OBJECT datatype.
-	DataTypeObject = &SnowflakeDataType{objectType.Byte()}
+	DataTypeObject = SnowflakeDataType{objectType.Byte()}
 	// DataTypeArray is a ARRAY datatype.
-	DataTypeArray = &SnowflakeDataType{arrayType.Byte()}
+	DataTypeArray = SnowflakeDataType{arrayType.Byte()}
 	// DataTypeBinary is a BINARY datatype.
-	DataTypeBinary = &SnowflakeDataType{binaryType.Byte()}
+	DataTypeBinary = SnowflakeDataType{binaryType.Byte()}
 	// DataTypeTime is a TIME datatype.
-	DataTypeTime = &SnowflakeDataType{timeType.Byte()}
+	DataTypeTime = SnowflakeDataType{timeType.Byte()}
 	// DataTypeBoolean is a BOOLEAN datatype.
-	DataTypeBoolean = &SnowflakeDataType{booleanType.Byte()}
+	DataTypeBoolean = SnowflakeDataType{booleanType.Byte()}
 )
 
-func clientTypeToInternal(cType *SnowflakeDataType) (iType snowflakeType, err error) {
-	if cType != nil && *cType != nil {
+func clientTypeToInternal(cType SnowflakeDataType) (iType snowflakeType, err error) {
+	if cType != nil {
 		switch {
-		case (*cType).Equals(*DataTypeFixed):
+		case cType.Equals(DataTypeFixed):
 			iType = fixedType
-		case (*cType).Equals(*DataTypeReal):
+		case cType.Equals(DataTypeReal):
 			iType = realType
-		case (*cType).Equals(*DataTypeText):
+		case cType.Equals(DataTypeText):
 			iType = textType
-		case (*cType).Equals(*DataTypeDate):
+		case cType.Equals(DataTypeDate):
 			iType = dateType
-		case (*cType).Equals(*DataTypeVariant):
+		case cType.Equals(DataTypeVariant):
 			iType = variantType
-		case (*cType).Equals(*DataTypeTimestampLtz):
+		case cType.Equals(DataTypeTimestampLtz):
 			iType = timestampLtzType
-		case (*cType).Equals(*DataTypeTimestampNtz):
+		case cType.Equals(DataTypeTimestampNtz):
 			iType = timestampNtzType
-		case (*cType).Equals(*DataTypeTimestampTz):
+		case cType.Equals(DataTypeTimestampTz):
 			iType = timestampTzType
-		case (*cType).Equals(*DataTypeObject):
+		case cType.Equals(DataTypeObject):
 			iType = objectType
-		case (*cType).Equals(*DataTypeArray):
+		case cType.Equals(DataTypeArray):
 			iType = arrayType
-		case (*cType).Equals(*DataTypeBinary):
+		case cType.Equals(DataTypeBinary):
 			iType = binaryType
-		case (*cType).Equals(*DataTypeTime):
+		case cType.Equals(DataTypeTime):
 			iType = timeType
-		case (*cType).Equals(*DataTypeBoolean):
+		case cType.Equals(DataTypeBoolean):
 			iType = booleanType
 		default:
-			return nullType, fmt.Errorf(errMsgInvalidByteArray, ([]byte)(*cType))
+			return nullType, fmt.Errorf(errMsgInvalidByteArray, ([]byte)(cType))
 		}
 	} else {
 		return nullType, fmt.Errorf(errMsgInvalidByteArray, nil)

--- a/datatype_test.go
+++ b/datatype_test.go
@@ -2,19 +2,14 @@
 
 package gosnowflake
 
-import (
-	"database/sql/driver"
-	"fmt"
-	"testing"
-)
-
 type tcDataTypeMode struct {
-	tp    driver.Value
+	tp    SnowflakeDataType
 	tmode snowflakeType
 	err   error
 }
 
-func TestDataTypeMode(t *testing.T) {
+/*
+func TestClientTypeToInternal(t *testing.T) {
 	var testcases = []tcDataTypeMode{
 		{tp: DataTypeFixed, tmode: fixedType, err: nil},
 		{tp: DataTypeReal, tmode: realType, err: nil},
@@ -29,11 +24,11 @@ func TestDataTypeMode(t *testing.T) {
 		{tp: DataTypeBinary, tmode: binaryType, err: nil},
 		{tp: DataTypeTime, tmode: timeType, err: nil},
 		{tp: DataTypeBoolean, tmode: booleanType, err: nil},
-		{tp: 123, tmode: nullType,
-			err: fmt.Errorf(errMsgInvalidByteArray, 123)},
+		{tp: nil, tmode: nullType,
+			err: fmt.Errorf(errMsgInvalidByteArray, nil)},
 	}
 	for _, ts := range testcases {
-		tmode, err := dataTypeMode(ts.tp)
+		tmode, err := clientTypeToInternal(ts.tp)
 		if ts.err == nil {
 			if err != nil {
 				t.Errorf("failed to get datatype mode: %v", err)
@@ -48,3 +43,5 @@ func TestDataTypeMode(t *testing.T) {
 		}
 	}
 }
+
+*/

--- a/datatype_test.go
+++ b/datatype_test.go
@@ -16,16 +16,19 @@ type tcDataTypeMode struct {
 
 func TestDataTypeMode(t *testing.T) {
 	var testcases = []tcDataTypeMode{
+		{tp: DataTypeFixed, tmode: fixedType, err: nil},
+		{tp: DataTypeReal, tmode: realType, err: nil},
+		{tp: DataTypeText, tmode: textType, err: nil},
+		{tp: DataTypeDate, tmode: dateType, err: nil},
+		{tp: DataTypeVariant, tmode: variantType, err: nil},
 		{tp: DataTypeTimestampLtz, tmode: timestampLtzType, err: nil},
 		{tp: DataTypeTimestampNtz, tmode: timestampNtzType, err: nil},
 		{tp: DataTypeTimestampTz, tmode: timestampTzType, err: nil},
-		{tp: DataTypeDate, tmode: dateType, err: nil},
-		{tp: DataTypeTime, tmode: timeType, err: nil},
+		{tp: DataTypeObject, tmode: objectType, err: nil},
+		{tp: DataTypeArray, tmode: arrayType, err: nil},
 		{tp: DataTypeBinary, tmode: binaryType, err: nil},
-		{tp: DataTypeFixed, tmode: fixedType,
-			err: fmt.Errorf(errMsgInvalidByteArray, DataTypeFixed)},
-		{tp: DataTypeReal, tmode: realType,
-			err: fmt.Errorf(errMsgInvalidByteArray, DataTypeFixed)},
+		{tp: DataTypeTime, tmode: timeType, err: nil},
+		{tp: DataTypeBoolean, tmode: booleanType, err: nil},
 		{tp: 123, tmode: nullType,
 			err: fmt.Errorf(errMsgInvalidByteArray, 123)},
 	}

--- a/datatype_test.go
+++ b/datatype_test.go
@@ -2,13 +2,17 @@
 
 package gosnowflake
 
+import (
+	"fmt"
+	"testing"
+)
+
 type tcDataTypeMode struct {
 	tp    SnowflakeDataType
 	tmode snowflakeType
 	err   error
 }
 
-/*
 func TestClientTypeToInternal(t *testing.T) {
 	var testcases = []tcDataTypeMode{
 		{tp: DataTypeFixed, tmode: fixedType, err: nil},
@@ -43,5 +47,3 @@ func TestClientTypeToInternal(t *testing.T) {
 		}
 	}
 }
-
-*/

--- a/statement.go
+++ b/statement.go
@@ -26,6 +26,7 @@ func (stmt *snowflakeStmt) NumInput() int {
 
 func (stmt *snowflakeStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.ExecContext")
+	logNamedValueArgs("statement.ExecContext", args)
 	return stmt.sc.ExecContext(ctx, stmt.query, args)
 }
 
@@ -36,6 +37,8 @@ func (stmt *snowflakeStmt) QueryContext(ctx context.Context, args []driver.Named
 
 func (stmt *snowflakeStmt) Exec(args []driver.Value) (driver.Result, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Exec")
+	logValueArgs("statement.Exec", args)
+
 	return stmt.sc.Exec(stmt.query, args)
 }
 

--- a/statement.go
+++ b/statement.go
@@ -43,16 +43,3 @@ func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Query")
 	return stmt.sc.Query(stmt.query, args)
 }
-
-// impl NamedValueChecker for *snowflakeStmt
-func (stmt *snowflakeStmt) CheckNamedValue(nv *driver.NamedValue) (err error) {
-	switch nv.Value.(type) {
-	case SnowflakeDataType:
-		// Pass SnowflakeDataType args through without modification so that we can
-		// distinguish them from arguments of type []byte
-		return nil
-	default:
-		// For all types other than SnowflakeDataType, fall back to the default value converter
-		return driver.ErrSkip
-	}
-}


### PR DESCRIPTION
### Description
This PR fixes 2 bugs in the way the driver parses argument type indicators:

#### First bug: only some types could be indicated explicitly

The driver's `ExecContext` method allows clients to pass a query and its arguments (e.g. `conn.ExecContext(ctx, query, arg1, arg2, arg3, ...)`). For some types of arguments, the client can also explicitly pass the argument's type as part of the arg list (e.g. `conn.ExecContext(ctx, query, arg1, typeForArg2, arg2, arg3, ...)`) . This is necessary to interpret a byte array as a raw binary input rather than a utf-8 encoded string, for example.

Prior to this PR, only a subset of the available data types could be specified explicitly (type indicators for other data types, such as booleans, would be interpreted as additional query arguments rather than as type indicators, which would lead to errors). This PR changes the binding code so that all data types can be specified explicitly.

Our application wants to be able to pass generic literals of any type to Snowflake. Since some types require explicit type args, we'd like to standardize on an approach where we always pass an explicit type arg.

#### Second bug: type indicators being interpreted as []byte values

Prior to this PR, all type indicators were raw []byte values (for example, the "subsequent arguments should have type BINARY" indicator had value `[]byte{10}`). This in-band signalling meant that once any argument was explicitly indicated to have type BINARY, all subsequent type indicators would be interpreted as values of type BINARY rather than type indicators. For example, if `typeForArg1` was `[]byte{10}`, then `conn.ExecContext(ctx, query, typeForArg1, arg1, typeForArg2, arg2)`, would be interpreted as having 3 arguments of type BINARY: `arg1`, `typeForArg2` (interpreted as a length-1 binary array), and `arg2`.

This PR fixes this issue by making the data type indicators a separate class so that they can always be distinguished from binary array values. This change should be backwards-compatible at the code level as long as clients are using the provided helper values for the type indicators and not hard-coding the binary array values.

One nuance here is that the Go sql API will strip all non-primitive type information by default (so the new `SnowflakeDataType` type would be stripped back down to a `[]byte`). Fortunately, the sql API also provides an escape hatch to get around this by specifying a custom `CheckNamedValue` function.

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
