### PR TITLE
Misc debugging aids for retry-behavior.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -63,6 +63,7 @@ type snowflakeConn struct {
 	ctx             context.Context
 	cfg             *Config
 	rest            *snowflakeRestful
+	restMu          sync.RWMutex // guard shutdown race
 	SequenceCounter uint64
 	QueryID         string
 	SQLState        string
@@ -220,6 +221,8 @@ func (sc *snowflakeConn) BeginTx(
 
 func (sc *snowflakeConn) cleanup() {
 	// must flush log buffer while the process is running.
+	sc.restMu.Lock()
+	defer sc.restMu.Unlock()
 	sc.rest = nil
 	sc.cfg = nil
 }

--- a/monitoring.go
+++ b/monitoring.go
@@ -325,6 +325,8 @@ func queryGraph(
 // deserializes it into the provided res (which is given as a generic interface
 // to allow different callers to request different views on the raw response)
 func (sc *snowflakeConn) getMonitoringResult(ctx context.Context, endpoint, qid string, res interface{}) error {
+	sc.restMu.RLock()
+	defer sc.restMu.RUnlock()
 	headers := make(map[string]string)
 	param := make(url.Values)
 	param.Add(requestGUIDKey, uuid.New().String())

--- a/retry.go
+++ b/retry.go
@@ -247,8 +247,13 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 				// This is currently used for Snowflake login. The caller must generate an error object based on HTTP status.
 				break
 			}
-			logger.WithContext(r.ctx).Warningf(
-				"failed http connection. HTTP Status: %v. retrying...\n", res.StatusCode)
+			if res.Request != nil {
+				logger.WithContext(r.ctx).Warningf(
+					"failed http connection. HTTP Status: %v. headers %v. request %v. retrying...\n", res.StatusCode, res.Header, res.Request.URL)
+			} else {
+				logger.WithContext(r.ctx).Warningf(
+					"failed http connection. HTTP Status: %v. headers %v. retrying...\n", res.StatusCode, res.Header)
+			}
 			res.Body.Close()
 		}
 		// uses decorrelated jitter backoff
@@ -262,8 +267,8 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 				if err != nil {
 					return nil, err
 				}
-				if res != nil {
-					return nil, fmt.Errorf("timeout after %s. HTTP Status: %v. Hanging?", r.timeout, res.StatusCode)
+				if res != nil && res.Request != nil {
+						return nil, fmt.Errorf("timeout after %s. HTTP Status: %v. Header: %v. request: %v. Hanging?", r.timeout, res.StatusCode, res.Header, res.Request.URL)
 				}
 				return nil, fmt.Errorf("timeout after %s. Hanging?", r.timeout)
 			}
@@ -277,7 +282,11 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 			rUpdater = newRetryUpdate(r.fullURL)
 		}
 		r.fullURL = rUpdater.replaceOrAdd(retryCounter)
-		logger.WithContext(r.ctx).Infof("sleeping %v. to timeout: %v. retrying", sleepTime, totalTimeout)
+		if res != nil && res.Request != nil {
+			logger.WithContext(r.ctx).Infof("sleeping %v. to timeout: %v. retry-count: %d retrying. headers: %v. request: %v", sleepTime, totalTimeout, retryCounter, res.Header, res.Request.URL)
+		} else {
+			logger.WithContext(r.ctx).Infof("sleeping %v. to timeout: %v. retry-count: %d retrying.", sleepTime, totalTimeout, retryCounter)
+		}
 
 		await := time.NewTimer(sleepTime)
 		select {
@@ -285,6 +294,11 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 			// retry the request
 		case <-r.ctx.Done():
 			await.Stop()
+			if res != nil && res.Request != nil {
+				logger.WithContext(r.ctx).Infof("abandoning request: retry-count: %d. headers: %v. request: %v", retryCounter, res.Header, res.Request.URL)
+			} else {
+				logger.WithContext(r.ctx).Infof("abandoning request: retry-count: %d.", retryCounter)
+			}
 			return res, r.ctx.Err()
 		}
 	}


### PR DESCRIPTION
- Add verbose info log trace for headers and request-url
- Also, merge is blocked because of a data-race in the test. Fixed that with a `RWMutex` with the write-lock on cleanup and the read-lock on monitoring-access.