### PR TITLE
Create Env-var flags to control debug logging within adapter for retries

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -642,7 +642,7 @@ func getAsync(
 func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, error) {
 	sc := &snowflakeConn{
 		SequenceCounter: 0,
-		ctx:             ctx,
+		ctx:             AddEnvFlags(ctx),
 		cfg:             &config,
 	}
 	var st http.RoundTripper = SnowflakeTransport

--- a/env_flags.go
+++ b/env_flags.go
@@ -10,10 +10,10 @@ import (
 // 0 => don't log anything
 // -1 => no limit to logging
 // a valid positive number => log response body bytes up to that number
-const responseBodySampleSize = "GOSF_RESPONSE_SAMPLE_SIZE"
+const responseBodySampleSize = "GOSNOWFLAKE_RESPONSE_SAMPLE_SIZE"
 
 // whether to dump details for retries.
-const verboseRetryLogging = "GOSF_VERBOSE_RETRY_LOGGING"
+const verboseRetryLogging = "GOSNOWFLAKE_VERBOSE_RETRY_LOGGING"
 
 const ctxEnvFlagsKey = "go-sf-env-var-flags"
 

--- a/env_flags.go
+++ b/env_flags.go
@@ -49,25 +49,34 @@ func AddEnvFlags(ctx context.Context) context.Context {
 	envFlags := make(EnvFlags)
 	envFlags[responseBodySampleSize] = ReadEnvIntFlag(responseBodySampleSize)
 	envFlags[verboseRetryLogging] = ReadEnvBoolFlag(verboseRetryLogging)
+	logger.WithContext(ctx).Infof("Debug: env-flags: %v\n", envFlags)
 	return context.WithValue(ctx, ctxEnvFlagsKey, envFlags)
 }
 
 func GetEnvIntFlag(ctx context.Context, flagName string) (int64, bool) {
-	envFlags := ctx.Value(ctxEnvFlagsKey).(EnvFlags)
+	envFlags, ok := ctx.Value(ctxEnvFlagsKey).(EnvFlags)
+	if !ok {
+		return 0, false
+	}
 	val, found := envFlags[flagName]
 	if !found {
 		return 0, false
 	}
 	i, ok := val.(int64)
+	logger.WithContext(ctx).Infof("Debug: int flag %s evaluated to %v\n", flagName, i)
 	return i, ok
 }
 
 func GetEnvBoolFlag(ctx context.Context, flagName string) (bool, bool) {
-	envFlags := ctx.Value(ctxEnvFlagsKey).(EnvFlags)
+	envFlags, ok := ctx.Value(ctxEnvFlagsKey).(EnvFlags)
+	if !ok {
+		return false, false
+	}
 	val, found := envFlags[flagName]
 	if !found {
 		return false, false
 	}
 	b, ok := val.(bool)
+	logger.WithContext(ctx).Infof("Debug: bool flag %s evaluated to %v\n", flagName, b)
 	return b, ok
 }

--- a/env_flags.go
+++ b/env_flags.go
@@ -15,8 +15,9 @@ const responseBodySampleSize = "GOSNOWFLAKE_RESPONSE_SAMPLE_SIZE"
 // whether to dump details for retries.
 const verboseRetryLogging = "GOSNOWFLAKE_VERBOSE_RETRY_LOGGING"
 
-const ctxEnvFlagsKey = "go-sf-env-var-flags"
+type ctxEnvFlagsKey struct{}
 
+// ReadEnvIntFlag gets an integer value from specified env-var.
 func ReadEnvIntFlag(flagName string) int64 {
 	flagVal := os.Getenv(flagName)
 	if flagVal == "" {
@@ -25,11 +26,11 @@ func ReadEnvIntFlag(flagName string) int64 {
 	intVal, err := strconv.ParseInt(flagVal, 10, 64)
 	if err != nil {
 		return 0
-	} else {
-		return intVal
 	}
+	return intVal
 }
 
+// ReadEnvBoolFlag gets a boolean value from specified env-var.
 func ReadEnvBoolFlag(flagName string) bool {
 	flagVal := os.Getenv(flagName)
 	if flagVal == "" {
@@ -38,22 +39,23 @@ func ReadEnvBoolFlag(flagName string) bool {
 	boolVal, err := strconv.ParseBool(flagVal)
 	if err != nil {
 		return false
-	} else {
-		return boolVal
 	}
+	return boolVal
 }
 
-type EnvFlags map[string]interface{}
+type envFlags map[string]interface{}
 
+// AddEnvFlags stores a map of env-var values into the supplied context.
 func AddEnvFlags(ctx context.Context) context.Context {
-	envFlags := make(EnvFlags)
+	envFlags := make(envFlags)
 	envFlags[responseBodySampleSize] = ReadEnvIntFlag(responseBodySampleSize)
 	envFlags[verboseRetryLogging] = ReadEnvBoolFlag(verboseRetryLogging)
-	return context.WithValue(ctx, ctxEnvFlagsKey, envFlags)
+	return context.WithValue(ctx, ctxEnvFlagsKey{}, envFlags)
 }
 
+// GetEnvIntFlag retrieves a specified integer flag value from the supplied context.
 func GetEnvIntFlag(ctx context.Context, flagName string) (int64, bool) {
-	envFlags, ok := ctx.Value(ctxEnvFlagsKey).(EnvFlags)
+	envFlags, ok := ctx.Value(ctxEnvFlagsKey{}).(envFlags)
 	if !ok {
 		return 0, false
 	}
@@ -65,8 +67,9 @@ func GetEnvIntFlag(ctx context.Context, flagName string) (int64, bool) {
 	return i, ok
 }
 
+// GetEnvBoolFlag retrieves a specified boolean flag value from the supplied context.
 func GetEnvBoolFlag(ctx context.Context, flagName string) (bool, bool) {
-	envFlags, ok := ctx.Value(ctxEnvFlagsKey).(EnvFlags)
+	envFlags, ok := ctx.Value(ctxEnvFlagsKey{}).(envFlags)
 	if !ok {
 		return false, false
 	}

--- a/env_flags.go
+++ b/env_flags.go
@@ -1,0 +1,73 @@
+package gosnowflake
+
+import (
+	"context"
+	"os"
+	"strconv"
+)
+
+// whether and how much to log, for a response-body.
+// 0 => don't log anything
+// -1 => no limit to logging
+// a valid positive number => log response body bytes up to that number
+const responseBodySampleSize = "GOSF_RESPONSE_SAMPLE_SIZE"
+
+// whether to dump details for retries.
+const verboseRetryLogging = "GOSF_VERBOSE_RETRY_LOGGING"
+
+const ctxEnvFlagsKey = "go-sf-env-var-flags"
+
+func ReadEnvIntFlag(flagName string) int64 {
+	flagVal := os.Getenv(flagName)
+	if flagVal == "" {
+		return 0
+	}
+	intVal, err := strconv.ParseInt(flagVal, 10, 64)
+	if err != nil {
+		return 0
+	} else {
+		return intVal
+	}
+}
+
+func ReadEnvBoolFlag(flagName string) bool {
+	flagVal := os.Getenv(flagName)
+	if flagVal == "" {
+		return false
+	}
+	boolVal, err := strconv.ParseBool(flagVal)
+	if err != nil {
+		return false
+	} else {
+		return boolVal
+	}
+}
+
+type EnvFlags map[string]interface{}
+
+func AddEnvFlags(ctx context.Context) context.Context {
+	envFlags := make(EnvFlags)
+	envFlags[responseBodySampleSize] = ReadEnvIntFlag(responseBodySampleSize)
+	envFlags[verboseRetryLogging] = ReadEnvBoolFlag(verboseRetryLogging)
+	return context.WithValue(ctx, ctxEnvFlagsKey, envFlags)
+}
+
+func GetEnvIntFlag(ctx context.Context, flagName string) (int64, bool) {
+	envFlags := ctx.Value(ctxEnvFlagsKey).(EnvFlags)
+	val, found := envFlags[flagName]
+	if !found {
+		return 0, false
+	}
+	i, ok := val.(int64)
+	return i, ok
+}
+
+func GetEnvBoolFlag(ctx context.Context, flagName string) (bool, bool) {
+	envFlags := ctx.Value(ctxEnvFlagsKey).(EnvFlags)
+	val, found := envFlags[flagName]
+	if !found {
+		return false, false
+	}
+	b, ok := val.(bool)
+	return b, ok
+}

--- a/env_flags.go
+++ b/env_flags.go
@@ -49,7 +49,6 @@ func AddEnvFlags(ctx context.Context) context.Context {
 	envFlags := make(EnvFlags)
 	envFlags[responseBodySampleSize] = ReadEnvIntFlag(responseBodySampleSize)
 	envFlags[verboseRetryLogging] = ReadEnvBoolFlag(verboseRetryLogging)
-	logger.WithContext(ctx).Infof("Debug: env-flags: %v\n", envFlags)
 	return context.WithValue(ctx, ctxEnvFlagsKey, envFlags)
 }
 
@@ -63,7 +62,6 @@ func GetEnvIntFlag(ctx context.Context, flagName string) (int64, bool) {
 		return 0, false
 	}
 	i, ok := val.(int64)
-	logger.WithContext(ctx).Infof("Debug: int flag %s evaluated to %v\n", flagName, i)
 	return i, ok
 }
 
@@ -77,6 +75,5 @@ func GetEnvBoolFlag(ctx context.Context, flagName string) (bool, bool) {
 		return false, false
 	}
 	b, ok := val.(bool)
-	logger.WithContext(ctx).Infof("Debug: bool flag %s evaluated to %v\n", flagName, b)
 	return b, ok
 }

--- a/retry.go
+++ b/retry.go
@@ -286,9 +286,8 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 				if res != nil {
 					if shouldDumpResponseInfo && res.Request != nil {
 						return nil, fmt.Errorf("timeout after %s. HTTP Status: %v. Header: %v. request: %v. body: %s. Hanging?", r.timeout, res.StatusCode, res.Header, res.Request.URL, sampledResponseBody)
-					} else {
-						return nil, fmt.Errorf("timeout after %s. HTTP Status: %v. Hanging?", r.timeout, res.StatusCode)
 					}
+					return nil, fmt.Errorf("timeout after %s. HTTP Status: %v. Hanging?", r.timeout, res.StatusCode)
 				}
 				return nil, fmt.Errorf("timeout after %s. Hanging?", r.timeout)
 			}

--- a/retry.go
+++ b/retry.go
@@ -208,9 +208,12 @@ func (r *retryHTTP) setBody(body []byte) *retryHTTP {
 	return r
 }
 
-const numSampledResponseBodyBytes = 5 * 1024
+func getBodyTrace(ctx context.Context, res *http.Response) []byte {
+	numSampledResponseBodyBytes, ok := GetEnvIntFlag(ctx, responseBodySampleSize)
+	if !ok {
+		return make([]byte, 0)
+	}
 
-func getBodyTrace(res *http.Response) []byte {
 	sampleReader := io.LimitReader(res.Body, numSampledResponseBodyBytes)
 	sampledResponseBytes := make([]byte, numSampledResponseBodyBytes)
 	sampleReader.Read(sampledResponseBytes)

--- a/retry.go
+++ b/retry.go
@@ -283,8 +283,12 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 				if err != nil {
 					return nil, err
 				}
-				if shouldDumpResponseInfo && res != nil && res.Request != nil {
-					return nil, fmt.Errorf("timeout after %s. HTTP Status: %v. Header: %v. request: %v. body: %s. Hanging?", r.timeout, res.StatusCode, res.Header, res.Request.URL, sampledResponseBody)
+				if res != nil {
+					if shouldDumpResponseInfo && res.Request != nil {
+						return nil, fmt.Errorf("timeout after %s. HTTP Status: %v. Header: %v. request: %v. body: %s. Hanging?", r.timeout, res.StatusCode, res.Header, res.Request.URL, sampledResponseBody)
+					} else {
+						return nil, fmt.Errorf("timeout after %s. HTTP Status: %v. Hanging?", r.timeout, res.StatusCode)
+					}
 				}
 				return nil, fmt.Errorf("timeout after %s. Hanging?", r.timeout)
 			}


### PR DESCRIPTION
- Add two flags to ensure that the current logging is a no-op in production

- `GOSNOWFLAKE_VERBOSE_RETRY_LOGGING`: unless explicitly true, none of the verbose tracing is enabled
- `GOSNOWFLAKE_RESPONSE_SAMPLE_SIZE`: unless set to some non-zero value, response body is not dumped


**Notes**:
1. these are driver-level env-var flags, and hence do not need the `MPLEX_` prefix for the running binary
2. these are loaded and cached when the connection struct is built
3. once the corresponding Multiplex build is in staging, we can bump up the second flag to dump larger response bodies