### PR TITLE
Dump env-vars that are read in for a connection.

### DIFF
--- a/env_flags.go
+++ b/env_flags.go
@@ -8,7 +8,6 @@ import (
 
 // whether and how much to log, for a response-body.
 // 0 => don't log anything
-// -1 => no limit to logging
 // a valid positive number => log response body bytes up to that number
 const responseBodySampleSize = "GOSNOWFLAKE_RESPONSE_SAMPLE_SIZE"
 

--- a/env_flags.go
+++ b/env_flags.go
@@ -50,6 +50,9 @@ func AddEnvFlags(ctx context.Context) context.Context {
 	envFlags := make(envFlags)
 	envFlags[responseBodySampleSize] = ReadEnvIntFlag(responseBodySampleSize)
 	envFlags[verboseRetryLogging] = ReadEnvBoolFlag(verboseRetryLogging)
+
+	logger.WithContext(ctx).Infof("Loaded environment flags: %v", envFlags)
+
 	return context.WithValue(ctx, ctxEnvFlagsKey{}, envFlags)
 }
 


### PR DESCRIPTION

Expect to see trace like:

```
INFO[0170]env_flags.go:54 gosnowflake.AddEnvFlags Loaded environment flags: map[GOSNOWFLAKE_RESPONSE_SAMPLE_SIZE:1000 GOSNOWFLAKE_VERBOSE_RETRY_LOGGING:true]
```

