### PR TITLE
SIG-17562: Update go.mod and upstream version dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,8 @@ Next, we want to create a merge commit that incorporates changes from the upstre
     # Cherry-pick changes from the fork as needed.
     git cherry-pick <hash> <hash> <hash>
 
+**Note**: ensure that `go.mod` uses `sigmacomputing/gosnowflake` as its module name, and (2) references the correct upstream *version* for `snowflakedb/gosnowflake`
+
 Now we can push the branch ``update-master-with-upstream`` to our fork's origin, and create a pull request.
 
 Once that's done, we can run the Multiplex benchmarks with the new version of gosnowflake. In your local copy of the mono-go repo, update Multiplex to use the version of gosnowflake in ``update-master-with-upstream``:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/snowflakedb/gosnowflake
+module github.com/sigmacomputing/gosnowflake
 
 go 1.16
 
@@ -13,6 +13,7 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
 	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/google/uuid v1.3.0
+	github.com/snowflakedb/gosnowflake v1.6.5
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/pierrec/lz4/v4 v4.1.11 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/snowflakedb/gosnowflake v1.6.5 h1:z7WfTtHly52GBX0VXVrelU285oiDKj/r3nTJ++YCK9o=
+github.com/snowflakedb/gosnowflake v1.6.5/go.mod h1:eK8Ei6XQfWlpRkK3+ZT1OFH82Qhz0TNyC+zioKqVrKA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,6 +123,9 @@ github.com/pkg/browser
 # github.com/sirupsen/logrus v1.8.1
 ## explicit
 github.com/sirupsen/logrus
+# github.com/snowflakedb/gosnowflake v1.6.5
+## explicit
+github.com/snowflakedb/gosnowflake
 # golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 ## explicit
 golang.org/x/crypto/ocsp


### PR DESCRIPTION
### Description
- Previous fix was missing the module name and upstream version-dependency
  - `s/snowflakedb/sigmacomputing` 
- (this is necessary before it can be linked in to Multiplex)
- Added a note to check for this on all future syncs.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
