### PR TITLE
SIG-17562: Add back ResultFetcher interface

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -725,3 +725,24 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 	}
 	return sc, nil
 }
+
+// FetchResult returns a Rows handle for a previously issued query,
+// given the snowflake query-id. This functionality is not used by the
+// go sql library but is exported to clients who can make use of this
+// capability explicitly.
+//
+// See the ResultFetcher interface.
+func (sc *snowflakeConn) FetchResult(ctx context.Context, qid string) (driver.Rows, error) {
+	return sc.buildRowsForRunningQuery(ctx, qid)
+}
+
+// ResultFetcher is an interface which allows a query result to be
+// fetched given the corresponding snowflake query-id.
+//
+// The raw gosnowflake connection implements this interface and we
+// export it so that clients can access this functionality, bypassing
+// the alternative which is the query it via the RESULT_SCAN table
+// function.
+type ResultFetcher interface {
+	FetchResult(ctx context.Context, qid string) (driver.Rows, error)
+}


### PR DESCRIPTION
**Cherry-picking** "_connection: export buildRowsForRunningQuery as FetchResult (#23)_"

Original commit: `20ebcf6ee7abd2d5e69cbf36fc5aa8dc7c7d4f18`

### Description

In certain cases we know the query-id of a result we wish to fetch and
it may be faster to fetch it directly through this method than to
query it using the `RESULT_SCAN` table function.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
