### PR TITLE
SIG-17456: Trap chunk-downloader errors with Sentry at Multiplex.

### DIFF
--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -285,6 +286,25 @@ func downloadChunk(ctx context.Context, scd *snowflakeChunkDownloader, idx int) 
 	logger.Infof("download start chunk: %v", idx+1)
 	defer scd.DoneDownloadCond.Broadcast()
 
+	defer func() {
+		var ret error
+		if err := recover(); err != nil {
+			logger.Infof("GoSnowflake chunk-downloader trapping error: %v", err)
+			stackTrace := make([]byte, 2048)
+			runtime.Stack(stackTrace, false)
+			// TODO(agam): properly format the stack-trace-payload
+			switch errResolved := err.(type) {
+			case string:
+				ret = fmt.Errorf("Panic from GoSnowflake (str): %s: %s", errResolved, stackTrace)
+			case error:
+				ret = fmt.Errorf("Panic from GoSnowflake (err): %w: %s", errResolved, stackTrace)
+			default:
+				ret = fmt.Errorf("Panic from GoSnowflake")
+			}
+		}
+		// Pass this through our error-channel
+		scd.ChunksError <- &chunkError{Index: idx, Error: ret}
+	}()
 	if err := scd.FuncDownloadHelper(ctx, scd, idx); err != nil {
 		logger.Errorf(
 			"failed to extract HTTP response body. URL: %v, err: %v", scd.ChunkMetas[idx].URL, err)
@@ -446,7 +466,7 @@ func (scd *streamChunkDownloader) start() error {
 			if readErr == io.EOF {
 				logger.WithContext(scd.ctx).Infof("downloading done. downloader id: %v", scd.id)
 			} else {
-				logger.WithContext(scd.ctx).Debugf("downloading error. downloader id: %v", scd.id)
+				logger.WithContext(scd.ctx).Infof("downloading error. downloader id: %v, err: %v", scd.id, readErr)
 			}
 			scd.readErr = readErr
 			close(scd.rowStream)

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -301,9 +301,9 @@ func downloadChunk(ctx context.Context, scd *snowflakeChunkDownloader, idx int) 
 			default:
 				ret = fmt.Errorf("Panic from GoSnowflake")
 			}
+			// Pass this through our error-channel
+			scd.ChunksError <- &chunkError{Index: idx, Error: ret}
 		}
-		// Pass this through our error-channel
-		scd.ChunksError <- &chunkError{Index: idx, Error: ret}
 	}()
 	if err := scd.FuncDownloadHelper(ctx, scd, idx); err != nil {
 		logger.Errorf(

--- a/rows.go
+++ b/rows.go
@@ -165,7 +165,9 @@ func (rows *snowflakeRows) Next(dest []driver.Value) (err error) {
 			rows.ChunkDownloader.reset()
 		} else {
 			// SIG-17456: we want to bubble up errors within GoSnowflake so they can be caught by Multiplex.
-			panic(err)
+			if innerPanic, ok := err.(*wrappedPanic); ok {
+				panic(innerPanic)
+			}
 		}
 		return err
 	}

--- a/rows.go
+++ b/rows.go
@@ -163,6 +163,9 @@ func (rows *snowflakeRows) Next(dest []driver.Value) (err error) {
 		// includes io.EOF
 		if err == io.EOF {
 			rows.ChunkDownloader.reset()
+		} else {
+			// SIG-17456: we want to bubble up errors within GoSnowflake so they can be caught by Multiplex.
+			panic(err)
 		}
 		return err
 	}


### PR DESCRIPTION
More context:
- We capture all "regular" `panic` calls within Multiplex
- However, there are separate execution trees that, when they encounter panics, lose stack-trace context.
- One way to trap them is to capture the stack-trace when they occur, and include a textual representation of this within the "body" of the error
- ... and then later to "re-panic", so that the error is registered by Multiplex _as if_ it had happened within _its_ call to `gosnowflake`


### Description
- Added a deferred handler to `chunk_downloader`
- Added a `panic` within the rows implementation
- Added a `wrappedPanic` error type to distinguish these situations from "plain" errors that we don't need to re-panic on
- Also, some lint + test fixes for https://github.com/sigmacomputing/gosnowflake/pull/45

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
