### PR TITLE
fix var inits

### DIFF
--- a/exec_resp_cache.go
+++ b/exec_resp_cache.go
@@ -36,8 +36,8 @@ const (
 // conditions in the acquire and release code. There should not be
 // a performance implication since these fns are called infrequently.
 var (
-	globalExecRespCacheMu sync.Mutex
-	globalExecRespCache   map[string]*execRespCache
+	globalExecRespCacheMu = sync.Mutex{}
+	globalExecRespCache   = map[string]*execRespCache{}
 )
 
 func acquireExecRespCache(id string) *execRespCache {


### PR DESCRIPTION
This fixes a bug w/ the init of the global vars in the new exec cache. 