### PR TITLE
Allow clients to specify DataTypeNull explicitly

### DIFF
--- a/bindings_test.go
+++ b/bindings_test.go
@@ -22,6 +22,20 @@ const (
 	selectAllSQL   = "select * from TEST_PREP_STATEMENT ORDER BY 1"
 )
 
+func TestBindingNull(t *testing.T) {
+	runTests(t, dsn, func(dbt *DBTest) {
+		dbt.mustExec("CREATE TABLE test (id int, c1 STRING, c2 BOOLEAN)")
+		_, err := dbt.db.Exec("INSERT INTO test VALUES (1, ?, ?)",
+			DataTypeText, "hello",
+			DataTypeNull, nil,
+		)
+		if err != nil {
+			dbt.Fatal(err)
+		}
+		dbt.mustExec("DROP TABLE IF EXISTS test")
+	})
+}
+
 func TestBindingFloat64(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		types := [2]string{"FLOAT", "DOUBLE"}

--- a/ci/scripts/test_component.sh
+++ b/ci/scripts/test_component.sh
@@ -12,4 +12,5 @@ if [[ -n "$GITHUB_WORKFLOW" ]]; then
 fi
 env | grep SNOWFLAKE | grep -v PASS | sort
 cd $TOPDIR
-go test -timeout 30m -race $COVFLAGS -v . 
+go test -timeout 30m -race $COVFLAGS -v .
+

--- a/converter_test.go
+++ b/converter_test.go
@@ -48,6 +48,7 @@ func TestGoTypeToSnowflake(t *testing.T) {
 		{in: DataTypeBinary, tmode: nil, out: changeType},
 		{in: DataTypeTime, tmode: nil, out: changeType},
 		{in: DataTypeBoolean, tmode: nil, out: changeType},
+		{in: DataTypeNull, tmode: nil, out: changeType},
 		// negative
 		{in: 123, tmode: nil, out: unSupportedType},
 		{in: int8(12), tmode: nil, out: unSupportedType},

--- a/datatype.go
+++ b/datatype.go
@@ -24,8 +24,8 @@ const (
 	binaryType
 	timeType
 	booleanType
-	// the following are not snowflake types per se but internal types
 	nullType
+	// the following are not snowflake types per se but internal types
 	sliceType
 	changeType
 	unSupportedType
@@ -92,6 +92,8 @@ var (
 	DataTypeTime = SnowflakeDataType{timeType.Byte()}
 	// DataTypeBoolean is a BOOLEAN datatype.
 	DataTypeBoolean = SnowflakeDataType{booleanType.Byte()}
+	// DataTypeNull is a NULL datatype.
+	DataTypeNull = SnowflakeDataType{nullType.Byte()}
 )
 
 func clientTypeToInternal(cType SnowflakeDataType) (iType snowflakeType, err error) {
@@ -123,6 +125,8 @@ func clientTypeToInternal(cType SnowflakeDataType) (iType snowflakeType, err err
 			iType = timeType
 		case cType.Equals(DataTypeBoolean):
 			iType = booleanType
+		case cType.Equals(DataTypeNull):
+			iType = nullType
 		default:
 			return nullType, fmt.Errorf(errMsgInvalidByteArray, ([]byte)(cType))
 		}

--- a/datatype_test.go
+++ b/datatype_test.go
@@ -28,6 +28,7 @@ func TestClientTypeToInternal(t *testing.T) {
 		{tp: DataTypeBinary, tmode: binaryType, err: nil},
 		{tp: DataTypeTime, tmode: timeType, err: nil},
 		{tp: DataTypeBoolean, tmode: booleanType, err: nil},
+		{tp: DataTypeNull, tmode: nullType, err: nil},
 		{tp: nil, tmode: nullType,
 			err: fmt.Errorf(errMsgInvalidByteArray, nil)},
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,13 +13,8 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
 	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/google/uuid v1.3.0
-	github.com/snowflakedb/gosnowflake v1.6.5
-	github.com/klauspost/compress v1.13.6 // indirect
-	github.com/pierrec/lz4/v4 v4.1.11 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/sirupsen/logrus v1.8.1
+	github.com/snowflakedb/gosnowflake v1.6.5
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
-	golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 // indirect
-	golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1 // indirect
-	golang.org/x/text v0.3.7 // indirect
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -101,7 +101,6 @@ github.com/google/uuid
 # github.com/jmespath/go-jmespath v0.4.0
 github.com/jmespath/go-jmespath
 # github.com/klauspost/compress v1.13.6
-## explicit
 github.com/klauspost/compress
 github.com/klauspost/compress/fse
 github.com/klauspost/compress/huff0
@@ -111,7 +110,6 @@ github.com/klauspost/compress/zstd/internal/xxhash
 # github.com/mattn/go-ieproxy v0.0.1
 github.com/mattn/go-ieproxy
 # github.com/pierrec/lz4/v4 v4.1.11
-## explicit
 github.com/pierrec/lz4/v4
 github.com/pierrec/lz4/v4/internal/lz4block
 github.com/pierrec/lz4/v4/internal/lz4errors
@@ -130,19 +128,16 @@ github.com/snowflakedb/gosnowflake
 ## explicit
 golang.org/x/crypto/ocsp
 # golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4
-## explicit
 golang.org/x/net/html
 golang.org/x/net/html/atom
 golang.org/x/net/http/httpproxy
 golang.org/x/net/idna
 # golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1
-## explicit
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 golang.org/x/sys/windows/registry
 # golang.org/x/text v0.3.7
-## explicit
 golang.org/x/text/secure/bidirule
 golang.org/x/text/transform
 golang.org/x/text/unicode/bidi


### PR DESCRIPTION
### Description
All query methods accept a `[]interface{}` of args. This slice can contain both values and type declarations (e.g. `[]interface{}{DataTypeText, "hello"}` will insert a single string-typed argument with value "hello"). Prior to this PR, clients could [specify data types explicitly](https://github.com/sigmacomputing/gosnowflake/pull/28/files) for all data types except for null (the only way to do this was to supply `nil` in the args slice). This had 2 problems:
1. null-valued args had to be special-cased, since they didn't follow the regular pattern of adding both a type declaration and a value to the args slice
2. we would hit a type error if a non-null arg for a column of type A was followed by a null arg for a column of type B != A. As an example, the query `SELECT ? as TEXT_COL, ? as BOOL_COL` with args `[]interface{}{DataTypeText, "hello", nil}` would fail since the `nil` would be interpreted as having type `DataTypeText` instead of `DataTypeBoolean`. This is because the driver assumes that an explicit type declaration applies to all subsequent arguments unless another explicit type declaration is provided (we had to keep this behavior for backwards compatibility).

The upshot of this PR is that we can now explicitly specify null-typed args (e.g. `[]interface{}{DataTypeNull, nil}`), which allows us to set both null and non-null args in a single query.

### Checklist
- [x] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
