### PR TITLE
SIG-18693: Avoid converting for local-timezone for the `timestampLtz` datatype.

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -527,7 +527,7 @@ func arrowToValue(
 			fraction := array.NewInt32Data(structData.Field(1).Data()).Int32Values()
 			for i := range *destcol {
 				if !srcValue.IsNull(i) {
-					(*destcol)[i] = time.Unix(epoch[i], int64(fraction[i])).In(localLocation)
+					(*destcol)[i] = time.Unix(epoch[i], int64(fraction[i]))
 				}
 			}
 		} else {


### PR DESCRIPTION

### Description
- https://github.com/snowflakedb/gosnowflake/pull/547 introduced a change to the value returned for `timestampLtz`
- Previously, `timestampNtz` explicitly had a timezone of `UTC`, while `timestampLtz` was "just a number" (both are unix timestamps)
- After this change, `timestampLtz` is converted to "the local-timezone" as passed in to the request-context
- We don't assume this in our response-processing, so it changes the _actual value shown in the result_ (this can be seen via a manual sql query)
- One fix (the one in this PR) is to simply negate this change (i.e. don't apply the local time-zone when returning the result from Snowflake)

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
