### PR TITLE
SIG-18794: Refactor the monitoring fetcher & auto-cancel async

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -566,17 +566,17 @@ type ResultFetcher interface {
 // MonitoringResultFetcher is an interface which allows to fetch monitoringResult
 // with snowflake connection and query-id.
 type MonitoringResultFetcher interface {
-	FetchMonitoringResult(queryID string) (*monitoringResult, error)
+	FetchMonitoringResult(queryID string, runtime time.Duration) (*monitoringResult, error)
 }
 
 // FetchMonitoringResult returns a monitoringResult object
 // Multiplex can call monitoringResult.Monitoring() to get the QueryMonitoringData
-func (sc *snowflakeConn) FetchMonitoringResult(queryID string) (*monitoringResult, error) {
+func (sc *snowflakeConn) FetchMonitoringResult(queryID string, runtime time.Duration) (*monitoringResult, error) {
 	if sc.rest == nil {
 		return nil, driver.ErrBadConn
 	}
 
 	// set the fake runtime just to bypass fast query
-	monitoringResult := mkMonitoringFetcher(sc, queryID, time.Minute*10)
+	monitoringResult := mkMonitoringFetcher(sc, queryID, runtime)
 	return monitoringResult, nil
 }

--- a/dsn.go
+++ b/dsn.go
@@ -94,6 +94,7 @@ type Config struct {
 	ConnectionID string
 }
 
+// MonitoringFetcherConfig provides some knobs to control the behavior of the monitoring data fetcher
 type MonitoringFetcherConfig struct {
 	// QueryRuntimeThreshold specifies the threshold, over which we'll fetch the monitoring
 	// data for a successful snowflake query. We use a time-based threshold, since there is

--- a/dsn.go
+++ b/dsn.go
@@ -15,12 +15,16 @@ import (
 )
 
 const (
-	defaultClientTimeout            = 900 * time.Second // Timeout for network round trip + read out http response
-	defaultLoginTimeout             = 60 * time.Second  // Timeout for retry for login EXCLUDING clientTimeout
-	defaultRequestTimeout           = 0 * time.Second   // Timeout for retry for request EXCLUDING clientTimeout
-	defaultJWTTimeout               = 60 * time.Second
-	defaultQueryMonitoringThreshold = 5 * time.Second
-	defaultDomain                   = ".snowflakecomputing.com"
+	defaultClientTimeout  = 900 * time.Second // Timeout for network round trip + read out http response
+	defaultLoginTimeout   = 60 * time.Second  // Timeout for retry for login EXCLUDING clientTimeout
+	defaultRequestTimeout = 0 * time.Second   // Timeout for retry for request EXCLUDING clientTimeout
+	defaultJWTTimeout     = 60 * time.Second
+	defaultDomain         = ".snowflakecomputing.com"
+
+	// default monitoring fetcher config values
+	defaultMonitoringFetcherQueryMonitoringThreshold = 45 * time.Second
+	defaultMonitoringFetcherMaxDuration              = 10 * time.Second
+	defaultMonitoringFetcherRetrySleepDuration       = 250 * time.Second
 )
 
 // ConfigBool is a type to represent true or false in the Config
@@ -82,14 +86,27 @@ type Config struct {
 
 	DisableTelemetry bool // indicates whether to disable telemetry
 
-	// QueryMonitoringDataThreshold specifies the threshold, over which we'll fetch the monitoring
-	// data for a Snowflake query. We use a time-based threshold, since there is a non-zero latency cost
-	// to fetch this data and we want to bound the additional latency. By default we bound to a 2% increase
-	// in latency - assuming worst case 100ms - when fetching this metadata.
-	QueryMonitoringThreshold time.Duration
+	// Monitoring fetcher config
+	MonitoringFetcher MonitoringFetcherConfig
+
 	// An identifier for this Config. Used to associate multiple connection instances with
 	// a single logical sql.DB connection.
 	ConnectionID string
+}
+
+type MonitoringFetcherConfig struct {
+	// QueryRuntimeThreshold specifies the threshold, over which we'll fetch the monitoring
+	// data for a successful snowflake query. We use a time-based threshold, since there is
+	// a non-zero latency cost to fetch this data, and we want to bound the additional latency.
+	// By default, we bound to a 2% increase in latency - assuming worst case 100ms - when
+	// fetching this metadata.
+	QueryRuntimeThreshold time.Duration
+
+	// max time to wait until we get a proper monitoring sample for a query
+	MaxDuration time.Duration
+
+	// Wait time between monitoring retries
+	RetrySleepDuration time.Duration
 }
 
 // ocspMode returns the OCSP mode in string INSECURE, FAIL_OPEN, FAIL_CLOSED
@@ -205,7 +222,15 @@ func DSN(cfg *Config) (dsn string, err error) {
 
 	params.Add("validateDefaultParameters", strconv.FormatBool(cfg.ValidateDefaultParameters != ConfigBoolFalse))
 
-	params.Add("queryMonitoringThreshold", strconv.FormatInt(int64(cfg.QueryMonitoringThreshold/time.Second), 10))
+	if cfg.MonitoringFetcher.QueryRuntimeThreshold != defaultMonitoringFetcherQueryMonitoringThreshold {
+		params.Add("monitoringFetcher_queryRuntimeThresholdMs", durationAsMillis(cfg.MonitoringFetcher.QueryRuntimeThreshold))
+	}
+	if cfg.MonitoringFetcher.MaxDuration != defaultMonitoringFetcherMaxDuration {
+		params.Add("monitoringFetcher_maxDurationMs", durationAsMillis(cfg.MonitoringFetcher.MaxDuration))
+	}
+	if cfg.MonitoringFetcher.RetrySleepDuration != defaultMonitoringFetcherRetrySleepDuration {
+		params.Add("monitoringFetcher_retrySleepDurationMs", durationAsMillis(cfg.MonitoringFetcher.RetrySleepDuration))
+	}
 
 	if cfg.ConnectionID != "" {
 		params.Add("connectionId", cfg.ConnectionID)
@@ -435,9 +460,16 @@ func fillMissingConfigParameters(cfg *Config) error {
 		cfg.ValidateDefaultParameters = ConfigBoolTrue
 	}
 
-	if cfg.QueryMonitoringThreshold == 0 {
-		cfg.QueryMonitoringThreshold = defaultQueryMonitoringThreshold
+	if cfg.MonitoringFetcher.QueryRuntimeThreshold == 0 {
+		cfg.MonitoringFetcher.QueryRuntimeThreshold = defaultMonitoringFetcherQueryMonitoringThreshold
 	}
+	if cfg.MonitoringFetcher.MaxDuration == 0 {
+		cfg.MonitoringFetcher.MaxDuration = defaultMonitoringFetcherMaxDuration
+	}
+	if cfg.MonitoringFetcher.RetrySleepDuration == 0 {
+		cfg.MonitoringFetcher.RetrySleepDuration = defaultMonitoringFetcherRetrySleepDuration
+	}
+
 	if cfg.ConnectionID == "" {
 		cfg.ConnectionID = newUUID().String()
 	}
@@ -627,10 +659,20 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			} else {
 				cfg.ValidateDefaultParameters = ConfigBoolFalse
 			}
-		case "queryMonitoringThreshold":
-			cfg.QueryMonitoringThreshold, err = parseTimeout(value)
+		case "monitoringFetcher_queryRuntimeThresholdMs":
+			cfg.MonitoringFetcher.QueryRuntimeThreshold, err = parseMillisToDuration(value)
 			if err != nil {
-				return
+				return err
+			}
+		case "monitoringFetcher_maxDurationMs":
+			cfg.MonitoringFetcher.MaxDuration, err = parseMillisToDuration(value)
+			if err != nil {
+				return err
+			}
+		case "monitoringFetcher_retrySleepDurationMs":
+			cfg.MonitoringFetcher.RetrySleepDuration, err = parseMillisToDuration(value)
+			if err != nil {
+				return err
 			}
 		default:
 			if cfg.Params == nil {
@@ -640,6 +682,19 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		}
 	}
 	return
+}
+
+func parseMillisToDuration(value string) (time.Duration, error) {
+	intValue, err := strconv.ParseInt(value, 10, 64)
+	if err == nil {
+		return time.Millisecond * time.Duration(intValue), nil
+	}
+
+	return 0, err
+}
+
+func durationAsMillis(duration time.Duration) string {
+	return strconv.FormatInt(duration.Milliseconds(), 10)
 }
 
 func parseTimeout(value string) (time.Duration, error) {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -612,7 +612,7 @@ func TestDSN(t *testing.T) {
 				Account:      "a-aofnadsf.somewhere.azure",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a-aofnadsf.somewhere.azure.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=somewhere.azure&validateDefaultParameters=true",
+			dsn: "u:p@a-aofnadsf.somewhere.azure.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=somewhere.azure&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -621,7 +621,7 @@ func TestDSN(t *testing.T) {
 				Account:      "a-aofnadsf.global",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a-aofnadsf.global.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=global&validateDefaultParameters=true",
+			dsn: "u:p@a-aofnadsf.global.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=global&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -631,7 +631,7 @@ func TestDSN(t *testing.T) {
 				Region:       "us-west-2",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a-aofnadsf.global.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=global&validateDefaultParameters=true",
+			dsn: "u:p@a-aofnadsf.global.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=global&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -650,7 +650,7 @@ func TestDSN(t *testing.T) {
 				Account:      "a",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&validateDefaultParameters=true",
+			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -660,7 +660,7 @@ func TestDSN(t *testing.T) {
 				Region:       "us-west-2",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&validateDefaultParameters=true",
+			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -670,7 +670,7 @@ func TestDSN(t *testing.T) {
 				Region:       "r",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.r.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=r&validateDefaultParameters=true",
+			dsn: "u:p@a.r.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=r&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -706,7 +706,7 @@ func TestDSN(t *testing.T) {
 				Account:      "a.e",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.e.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=e&validateDefaultParameters=true",
+			dsn: "u:p@a.e.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=e&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -716,7 +716,7 @@ func TestDSN(t *testing.T) {
 				Region:       "us-west-2",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.e.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=e&validateDefaultParameters=true",
+			dsn: "u:p@a.e.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=e&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -745,7 +745,7 @@ func TestDSN(t *testing.T) {
 				Application:        "special go",
 				ConnectionID:       testConnectionID,
 			},
-			dsn: "u:p@a.b.snowflakecomputing.com:443?application=special+go&connectionId=abcd-0123-4567-1234&database=db&loginTimeout=10&ocspFailOpen=true&passcode=db&passcodeInPassword=true&queryMonitoringThreshold=5&region=b&requestTimeout=300&role=ro&schema=sc&validateDefaultParameters=true",
+			dsn: "u:p@a.b.snowflakecomputing.com:443?application=special+go&connectionId=abcd-0123-4567-1234&database=db&loginTimeout=10&ocspFailOpen=true&passcode=db&passcodeInPassword=true&region=b&requestTimeout=300&role=ro&schema=sc&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -755,7 +755,7 @@ func TestDSN(t *testing.T) {
 				Authenticator: AuthTypeExternalBrowser,
 				ConnectionID:  testConnectionID,
 			},
-			dsn: "u:p@a.snowflakecomputing.com:443?authenticator=externalbrowser&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&validateDefaultParameters=true",
+			dsn: "u:p@a.snowflakecomputing.com:443?authenticator=externalbrowser&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -769,7 +769,7 @@ func TestDSN(t *testing.T) {
 				},
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.snowflakecomputing.com:443?authenticator=https%3A%2F%2Fsc.okta.com&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&validateDefaultParameters=true",
+			dsn: "u:p@a.snowflakecomputing.com:443?authenticator=https%3A%2F%2Fsc.okta.com&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -781,7 +781,7 @@ func TestDSN(t *testing.T) {
 				},
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.e.snowflakecomputing.com:443?TIMESTAMP_OUTPUT_FORMAT=MM-DD-YYYY&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=e&validateDefaultParameters=true",
+			dsn: "u:p@a.e.snowflakecomputing.com:443?TIMESTAMP_OUTPUT_FORMAT=MM-DD-YYYY&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=e&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -793,7 +793,7 @@ func TestDSN(t *testing.T) {
 				},
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:%3A%40abc@a.e.snowflakecomputing.com:443?TIMESTAMP_OUTPUT_FORMAT=MM-DD-YYYY&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=e&validateDefaultParameters=true",
+			dsn: "u:%3A%40abc@a.e.snowflakecomputing.com:443?TIMESTAMP_OUTPUT_FORMAT=MM-DD-YYYY&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=e&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -803,7 +803,7 @@ func TestDSN(t *testing.T) {
 				OCSPFailOpen: OCSPFailOpenTrue,
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&validateDefaultParameters=true",
+			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -813,7 +813,7 @@ func TestDSN(t *testing.T) {
 				OCSPFailOpen: OCSPFailOpenFalse,
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=false&queryMonitoringThreshold=5&validateDefaultParameters=true",
+			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=false&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -823,7 +823,7 @@ func TestDSN(t *testing.T) {
 				ValidateDefaultParameters: ConfigBoolFalse,
 				ConnectionID:              testConnectionID,
 			},
-			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&validateDefaultParameters=false",
+			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&validateDefaultParameters=false",
 		},
 		{
 			cfg: &Config{
@@ -833,7 +833,7 @@ func TestDSN(t *testing.T) {
 				ValidateDefaultParameters: ConfigBoolTrue,
 				ConnectionID:              testConnectionID,
 			},
-			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&validateDefaultParameters=true",
+			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -843,7 +843,7 @@ func TestDSN(t *testing.T) {
 				InsecureMode: true,
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&insecureMode=true&ocspFailOpen=true&queryMonitoringThreshold=5&validateDefaultParameters=true",
+			dsn: "u:p@a.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&insecureMode=true&ocspFailOpen=true&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -852,7 +852,7 @@ func TestDSN(t *testing.T) {
 				Account:      "a.b.c",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.b.c.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=b.c&validateDefaultParameters=true",
+			dsn: "u:p@a.b.c.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -862,7 +862,7 @@ func TestDSN(t *testing.T) {
 				Region:       "us-west-2",
 				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.b.c.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=b.c&validateDefaultParameters=true",
+			dsn: "u:p@a.b.c.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -882,17 +882,47 @@ func TestDSN(t *testing.T) {
 				ClientTimeout: 300 * time.Second,
 				ConnectionID:  testConnectionID,
 			},
-			dsn: "u:p@a.b.c.snowflakecomputing.com:443?clientTimeout=300&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=5&region=b.c&validateDefaultParameters=true",
+			dsn: "u:p@a.b.c.snowflakecomputing.com:443?clientTimeout=300&connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
-				User:                     "u",
-				Password:                 "p",
-				Account:                  "a.e",
-				QueryMonitoringThreshold: 20 * time.Second,
-				ConnectionID:             testConnectionID,
+				User:     "u",
+				Password: "p",
+				Account:  "a.e",
+				MonitoringFetcher: MonitoringFetcherConfig{
+					QueryRuntimeThreshold: time.Second * 56,
+				},
+				ConnectionID: testConnectionID,
 			},
-			dsn: "u:p@a.e.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&queryMonitoringThreshold=20&region=e&validateDefaultParameters=true",
+			dsn: "u:p@a.e.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&monitoringFetcher_queryRuntimeThresholdMs=56000&ocspFailOpen=true&region=e&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a.e",
+				MonitoringFetcher: MonitoringFetcherConfig{
+					QueryRuntimeThreshold: time.Second * 56,
+					MaxDuration:           time.Second * 14,
+					RetrySleepDuration:    time.Millisecond * 45,
+				},
+				ConnectionID: testConnectionID,
+			},
+			dsn: "u:p@a.e.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&monitoringFetcher_maxDurationMs=14000&monitoringFetcher_queryRuntimeThresholdMs=56000&monitoringFetcher_retrySleepDurationMs=45&ocspFailOpen=true&region=e&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a.e",
+				MonitoringFetcher: MonitoringFetcherConfig{
+					QueryRuntimeThreshold: defaultMonitoringFetcherQueryMonitoringThreshold,
+					MaxDuration:           defaultMonitoringFetcherMaxDuration,
+					RetrySleepDuration:    defaultMonitoringFetcherRetrySleepDuration,
+				},
+				ConnectionID: testConnectionID,
+			},
+			dsn: "u:p@a.e.snowflakecomputing.com:443?connectionId=abcd-0123-4567-1234&ocspFailOpen=true&region=e&validateDefaultParameters=true",
 		},
 	}
 	for _, test := range testcases {

--- a/monitoring.go
+++ b/monitoring.go
@@ -274,7 +274,7 @@ func (sc *snowflakeConn) buildRowsForRunningQuery(
 
 func mkMonitoringFetcher(sc *snowflakeConn, qid string, runtime time.Duration) *monitoringResult {
 	// Exit early if this was a "fast" query
-	if runtime < sc.cfg.QueryMonitoringThreshold {
+	if runtime < sc.cfg.MonitoringFetcher.QueryRuntimeThreshold {
 		return nil
 	}
 
@@ -297,14 +297,31 @@ func monitoring(
 ) {
 	defer close(resp)
 
-	ctx, cancel := context.WithTimeout(context.Background(), sc.rest.RequestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), sc.cfg.MonitoringFetcher.MaxDuration)
 	defer cancel()
 
-	var m monitoringResponse
-	err := sc.getMonitoringResult(ctx, "queries", qid, &m)
-	if err == nil && len(m.Data.Queries) == 1 {
-		resp <- &m.Data.Queries[0]
+	var queryMonitoringData *QueryMonitoringData
+	for {
+		var m monitoringResponse
+		if err := sc.getMonitoringResult(ctx, "queries", qid, &m); err != nil {
+			break
+		}
+
+		if len(m.Data.Queries) == 1 {
+			queryMonitoringData = &m.Data.Queries[0]
+			if !strToQueryStatus(queryMonitoringData.Status).isRunning() {
+				break
+			}
+		}
+
+		time.Sleep(sc.cfg.MonitoringFetcher.RetrySleepDuration)
 	}
+
+	if queryMonitoringData != nil {
+		resp <- queryMonitoringData
+	}
+
+	return
 }
 
 func queryGraph(
@@ -315,7 +332,7 @@ func queryGraph(
 	defer close(resp)
 
 	// Bound the GET request to 1 second in the absolute worst case.
-	ctx, cancel := context.WithTimeout(context.Background(), sc.rest.RequestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), sc.cfg.MonitoringFetcher.MaxDuration)
 	defer cancel()
 
 	var qg queryGraphResponse

--- a/restful.go
+++ b/restful.go
@@ -236,7 +236,7 @@ func postRestfulQueryHelper(
 
 		// if asynchronous query in progress, kick off retrieval but return object
 		if respd.Code == queryInProgressAsyncCode && isAsyncMode(ctx) {
-			return sr.processAsync(ctx, &respd, headers, timeout, cfg)
+			return sr.processAsync(ctx, &respd, headers, timeout, cfg, requestID)
 		}
 		for isSessionRenewed || respd.Code == queryInProgressCode ||
 			respd.Code == queryInProgressAsyncCode {

--- a/rows.go
+++ b/rows.go
@@ -37,6 +37,7 @@ type snowflakeRows struct {
 	err                 error
 	errChannel          chan error
 	monitoring          *monitoringResult
+	asyncRequestID      uuid
 }
 
 type snowflakeValue interface{}


### PR DESCRIPTION
### Description

Allow an async query to autocancel on context timeout
Added more configuration flag to the monitoring fetcher
Allow the monitoring fetcher to loop until it gets the stats for the completed query

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
