### PR TITLE
SIG-18794: Fix handling of results response for canceled queries

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -253,6 +253,20 @@ func (sc *snowflakeConn) rowsForRunningQuery(
 		}
 		return err
 	}
+	if !resp.Success {
+		message := resp.Message
+		code, err := strconv.Atoi(resp.Code)
+		if err != nil {
+			code = ErrQueryStatus
+			message = fmt.Sprintf("%s: (failed to parse original code: %s: %s)", message, resp.Code, err.Error())
+		}
+		return (&SnowflakeError{
+			Number:   code,
+			SQLState: resp.Data.SQLState,
+			Message:  message,
+			QueryID:  resp.Data.QueryID,
+		}).exceptionTelemetry(sc)
+	}
 	rows.addDownloader(populateChunkDownloader(ctx, sc, resp.Data))
 	return nil
 }


### PR DESCRIPTION
### Description

When retrieving results for a query that was canceled, the driver didn't parse the response correctly. 

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
