### PR TITLE
Disable go 1.1.6 from build/test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,7 @@ jobs:
             matrix:
                 # TODO(SIG-12289): re-enable tests on cloud providers other than AWS
                 cloud: [ 'AWS' ]
-                go: [ '1.17', '1.16' ]
+                go: [ '1.17' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Ubuntu
         steps:
             - uses: actions/checkout@v1


### PR DESCRIPTION
### Description
Tooling fails on go 1.16 (long since end-of-lifed), remove it.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
