### PR TITLE
[SIG-23142]Make gosnowflake driver decode raw arrow records fetched from snowflake to sigma-desired arrow records

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -1039,6 +1039,12 @@ func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.L
 				} else {
 					t = &arrow.Float64Type{}
 				}
+			case arrow.INT8, arrow.INT16, arrow.INT32:
+				if srcColumnMeta.Scale != 0 {
+					t = &arrow.Float64Type{}
+				} else {
+					t = &arrow.Int64Type{}
+				}
 			default:
 				if srcColumnMeta.Scale != 0 {
 					t = &arrow.Float64Type{}
@@ -1049,9 +1055,9 @@ func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.L
 		case timeType:
 			t = &arrow.Time64Type{}
 		case timestampNtzType, timestampTzType:
-			t = &arrow.TimestampType{}
+			t = &arrow.TimestampType{Unit: arrow.Millisecond}
 		case timestampLtzType:
-			t = &arrow.TimestampType{TimeZone: loc.String()}
+			t = &arrow.TimestampType{Unit: arrow.Millisecond, TimeZone: loc.String()}
 		default:
 			converted = false
 		}

--- a/converter_test.go
+++ b/converter_test.go
@@ -740,6 +740,16 @@ func TestArrowToRecord(t *testing.T) {
 			nrows:    2,
 			builder:  array.NewInt8Builder(pool),
 			append:   func(b array.Builder, vs interface{}) { b.(*array.Int8Builder).AppendValues(vs.([]int8), valids) },
+			compare: func(src interface{}, convertedRec array.Record) int {
+				srcvs := src.([]int8)
+				for i, val := range array.NewInt64Data(convertedRec.Column(0).Data()).Int64Values() {
+					rawInt := int64(srcvs[i])
+					if rawInt != val {
+						return i
+					}
+				}
+				return -1
+			},
 		},
 		{
 			logical:  "fixed",
@@ -749,6 +759,16 @@ func TestArrowToRecord(t *testing.T) {
 			nrows:    2,
 			builder:  array.NewInt16Builder(pool),
 			append:   func(b array.Builder, vs interface{}) { b.(*array.Int16Builder).AppendValues(vs.([]int16), valids) },
+			compare: func(src interface{}, convertedRec array.Record) int {
+				srcvs := src.([]int16)
+				for i, val := range array.NewInt64Data(convertedRec.Column(0).Data()).Int64Values() {
+					rawInt := int64(srcvs[i])
+					if rawInt != val {
+						return i
+					}
+				}
+				return -1
+			},
 		},
 		{
 			logical:  "fixed",
@@ -758,6 +778,16 @@ func TestArrowToRecord(t *testing.T) {
 			nrows:    2,
 			builder:  array.NewInt32Builder(pool),
 			append:   func(b array.Builder, vs interface{}) { b.(*array.Int32Builder).AppendValues(vs.([]int32), valids) },
+			compare: func(src interface{}, convertedRec array.Record) int {
+				srcvs := src.([]int32)
+				for i, val := range array.NewInt64Data(convertedRec.Column(0).Data()).Int64Values() {
+					rawInt := int64(srcvs[i])
+					if rawInt != val {
+						return i
+					}
+				}
+				return -1
+			},
 		},
 		{
 			logical:  "fixed",


### PR DESCRIPTION
### Description
Make gosnowflake driver decode raw arrow records fetched from snowflake to sigma-desired arrow records, including all integers casted to Int64, all timestamps are in millisecond, etc.

The rationale to complete the cast here instead of in evaluator is that the driver needs to scan through the fetched raw arrow records anyway, instead of building the non-desired arrow chunks here and casting them in evaluator, we save time if the driver returns directly whatever arrow encoding sigma needs. For example, previously the driver is decoding all timestamps in nanoseconds, from struct-type arrow records, and evaluator will have to cast them to milliseconds, rather redundantly.

I am not so sure about the integers. According to snowflake, all numbers are stored as decimals internally: https://docs.snowflake.com/en/sql-reference/data-types-numeric.html#int-integer-bigint-smallint-tinyint-byteint
Therefore, I assume most of the decoding here should be converting snowflake numbers based on the scale and precision metadata. The cases similar to where snowflake gives us Int8 arrow records with 0-scale may be just for test purpose, but I convert them to Int64 anyway and fix the tests to expect so.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
