### PR TITLE
[SIG-23247] Make the code path pass raw arrow records directly

### DIFF
--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -97,6 +97,7 @@ func (arc *arrowResultChunk) passRawArrowBatch(scd *snowflakeChunkDownloader) (*
 			if field.Nullable != scd.RowSet.RowType[idx].Nullable ||
 				field.Name != scd.RowSet.RowType[idx].Name ||
 				!compareMetadata(field.Metadata, scd.RowSet.RowType[idx]) {
+				logger.Error("Lack or mismatch of necessary metadata to decode fetched raw arrow records")
 				return nil, &SnowflakeError{
 					Message: "Lack or mismatch of necessary metadata to decode fetched raw arrow records",
 				}

--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -111,7 +111,7 @@ func compareMetadata(actual arrow.Metadata, expected execResponseRowType) bool {
 	for idx, key := range actual.Keys() {
 		switch strings.ToUpper(key) {
 		case "LOGICALTYPE":
-			if strings.EqualFold(actual.Values()[idx], expected.Type) {
+			if !strings.EqualFold(actual.Values()[idx], expected.Type) {
 				return false
 			}
 		case "PRECISION":

--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -102,6 +102,7 @@ func (arc *arrowResultChunk) passRawArrowBatch(scd *snowflakeChunkDownloader) (*
 				}
 			}
 		}
+		rawRecord.Retain()
 		records = append(records, rawRecord)
 	}
 	return &records, nil

--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -116,17 +116,13 @@ func compareMetadata(actual arrow.Metadata, expected execResponseRowType) bool {
 			if !strings.EqualFold(actual.Values()[idx], expected.Type) {
 				return false
 			}
-		case "PRECISION":
-			if i64, err := strconv.ParseInt(actual.Values()[idx], 10, 64); err != nil || i64 != expected.Precision {
-				return false
-			}
 		case "SCALE":
-			if i64, err := strconv.ParseInt(actual.Values()[idx], 10, 64); err != nil || i64 != expected.Scale {
-				return false
-			}
-		case "BYTELENGTH":
-			if i64, err := strconv.ParseInt(actual.Values()[idx], 10, 64); err != nil || i64 != expected.ByteLength {
-				return false
+			switch strings.ToUpper(expected.Type) {
+			case "FIXED", "TIMESTAMP_LTZ", "TIMESTAMP_NTZ":
+				if i64, err := strconv.ParseInt(actual.Values()[idx], 10, 64); err != nil || i64 != expected.Scale {
+					return false
+				}
+			default:
 			}
 		default:
 		}

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -288,7 +288,7 @@ func (scd *snowflakeChunkDownloader) startArrowBatches() error {
 	}
 	// decode first chunk if possible
 	if firstArrowChunk.allocator != nil {
-		scd.FirstBatch.rec, err = firstArrowChunk.decodeArrowBatch(scd)
+		scd.FirstBatch.rec, err = firstArrowChunk.passRawArrowBatch(scd)
 		if err != nil {
 			return err
 		}
@@ -467,7 +467,7 @@ func decodeChunk(scd *snowflakeChunkDownloader, idx int, bufStream *bufio.Reader
 			loc,
 		}
 		if usesArrowBatches(scd.ctx) {
-			if scd.ArrowBatches[idx].rec, err = arc.decodeArrowBatch(scd); err != nil {
+			if scd.ArrowBatches[idx].rec, err = arc.passRawArrowBatch(scd); err != nil {
 				return err
 			}
 			// updating metadata


### PR DESCRIPTION
### Description
After discussion, we decide that in this arrow batch new feature code path, we should decode whatever the raw arrow chunks fetched from snowflake in evaluator instead of in the driver (part of multiplex), as long as we have the enough information to do so. Luckily, the gosnowflake driver has the necessary information loaded in the arrow records' schema that we can pass along.  

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
