### PR TITLE
[SIG-23669]Have arrow batches call Fetch() with ctx passed into the driver

### DIFF
--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -736,14 +736,14 @@ type ArrowBatch struct {
 }
 
 // Fetch returns an array of records representing a chunk in the query
-func (rb *ArrowBatch) Fetch() (*[]array.Record, error) {
+func (rb *ArrowBatch) Fetch(ctx context.Context) (*[]array.Record, error) {
 	// chunk has already been downloaded
 	if rb.rec != nil {
 		// updating metadata
 		rb.rowCount = countArrowBatchRows(rb.rec)
 		return rb.rec, nil
 	}
-	if err := rb.funcDownloadHelper(context.Background(), rb.scd, rb.idx); err != nil {
+	if err := rb.funcDownloadHelper(ctx, rb.scd, rb.idx); err != nil {
 		return nil, err
 	}
 	return rb.rec, nil

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -435,7 +435,7 @@ func TestWithArrowBatches(t *testing.T) {
 			defer wg.Done()
 
 			for i := range chunks {
-				rec, err := batches[i].Fetch()
+				rec, err := batches[i].Fetch(ctx)
 				if err != nil {
 					t.Error(err)
 				}


### PR DESCRIPTION
### Description
Currently the arrow batch objects Fetch() internally creates a new background context. We should have the multiplex query ctx passed to the gosnowflake driver so this Fetch() can time out, or get canceled by multiplex.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
