### PR TITLE
[Fix] Check that raw records contains logical_type metadata

### DIFF
--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -123,7 +123,7 @@ func checkMetadata(actual arrow.Metadata, expected execResponseRowType) bool {
 			}
 		case "SCALE":
 			switch strings.ToUpper(expected.Type) {
-			case "FIXED", "TIMESTAMP_LTZ", "TIMESTAMP_NTZ":
+			case "FIXED", "TIME", "TIMESTAMP_LTZ", "TIMESTAMP_NTZ":
 				if i64, err := strconv.ParseInt(actual.Values()[idx], 10, 64); err != nil || i64 != expected.Scale {
 					return false
 				}


### PR DESCRIPTION
Resolves [SIG-24206]

### Description
Just realized that the driver does not guarantee the raw records contain the necessary `logical type `metadata. Although missing `logical type` will be caught in evaluator, it makes better sense that we catch this error early in multiplex so no redundant network load introduced.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

[SIG-24206]: https://sigmacomputing.atlassian.net/browse/SIG-24206