### PR TITLE
make snowflakeConn struct goroutine safe

### DIFF
--- a/cmd/hack6.go
+++ b/cmd/hack6.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+    "fmt"
+    "path"
+    "io"
+    "path/filepath"
+    "os"
+    "encoding/json"
+    "strings"
+    "log"
+    "context"
+    "time"
+    "database/sql/driver"
+    "sync"
+
+    snowflake "github.com/sigmacomputing/gosnowflake"
+)
+
+type SnowflakeAdapter struct {
+
+}
+
+func init() {
+    logger := snowflake.GetLogger()
+    _ = logger.SetLogLevel("error")
+}
+
+const APPLICATION = "PizzaOracle"
+
+func main() {
+    c := loadTestConfig()
+
+    // This is all the information we need to create a snowflake connections
+    config := snowflake.Config{
+        Account: strings.Replace(c.Server, ".snowflakecomputing.com", "", 1),
+        Host: c.Host,
+        Warehouse: c.Warehouse,
+        Role: c.Role,
+    
+        Application: APPLICATION,
+        InsecureMode: false,
+
+        Params: map[string]*string{
+            "timezone": StrP("UTC"),
+            "abort_detached_query": StrP("true"),
+        },
+
+        ClientTimeout: 900 * time.Second,
+        LoginTimeout: 30 * time.Second,
+        RequestTimeout: 30 * time.Second,
+
+        ValidateDefaultParameters: snowflake.ConfigBoolFalse,
+
+        ConnectionID: "my-test-connection",
+
+        MonitoringFetcher: snowflake.MonitoringFetcherConfig{
+            QueryRuntimeThreshold: 2 * time.Minute,
+            MaxDuration: 10 * time.Second,
+            RetrySleepDuration: 250 * time.Millisecond,
+        },
+    }
+
+    config.Authenticator = snowflake.AuthTypeSnowflake
+    config.User = c.User
+    config.Password = c.Password
+
+    // Apparently calling the DSN() method will fill in some additional
+    // information required to communicate with snowflake.
+    snowflake.DSN(&config)
+
+    d := snowflake.SnowflakeDriver{}
+
+    conn, err := d.OpenWithConfig(context.TODO(), config)
+    if err != nil {
+        log.Fatal(err)
+    }
+    var wg sync.WaitGroup
+    for i := 0; i < 10; i++ {
+        wg.Add(1)
+        go func() {
+            defer wg.Done()
+            var start = time.Now()
+            stmt, err := conn.Prepare("SELECT 1")
+            if err != nil {
+                log.Fatal(err)
+                return
+            }
+            stmt.Exec([]driver.Value{})
+            if err != nil {
+                log.Fatal(err)
+            }
+            fmt.Println("ping conn in", time.Since(start))
+            fmt.Printf("%T\n", conn)
+        }()
+    }
+
+    wg.Wait()
+}
+
+func StrP(s string) *string {
+    return &s
+}
+
+
+type SnowflakeConfig struct {
+    Server string
+    Warehouse string
+    Host string
+    User string
+    Role string
+    Password string
+}
+
+func loadTestConfig() SnowflakeConfig {
+	data, err := ReadDbSpec("snowflake")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	config := SnowflakeConfig{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		log.Fatal(err)
+	}
+
+	return config
+}
+
+func ReadDbSpec(engine string) ([]byte, error) {
+	basedir, found := os.LookupEnv("MPLEX_TEST_CONNECTION_DIR")
+
+	if found {
+		basedir, _ = filepath.Abs(basedir)
+	} else {
+        log.Fatal("MPLEX_TEST_CONNECTION_DIR must be set")
+	}
+
+	file, err := os.Open(path.Join(basedir, fmt.Sprintf("%s.json", engine)))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	buf := bytes.NewBuffer(nil)
+	_, err = io.Copy(buf, file)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/connection.go
+++ b/connection.go
@@ -58,8 +58,8 @@ type snowflakeConn struct {
 	rest            *snowflakeRestful
 	restMu          sync.RWMutex // guard shutdown race
 	SequenceCounter uint64
-	QueryID         string
-	SQLState        string
+	//QueryID         string
+	//SQLState        string
 	telemetry       *snowflakeTelemetry
 	internal        InternalClient
 	execRespCache   *execRespCache
@@ -146,13 +146,17 @@ func (sc *snowflakeConn) exec(
 	}
 
 	logger.WithContext(ctx).Info("Exec/Query SUCCESS")
-	sc.cfg.Database = data.Data.FinalDatabaseName
-	sc.cfg.Schema = data.Data.FinalSchemaName
-	sc.cfg.Role = data.Data.FinalRoleName
-	sc.cfg.Warehouse = data.Data.FinalWarehouseName
-	sc.QueryID = data.Data.QueryID
-	sc.SQLState = data.Data.SQLState
-	sc.populateSessionParameters(data.Data.Parameters)
+
+    // Now if the counter matches then update the data
+    // In theory the final names will always be the same for the life of the connection?
+	//sc.cfg.Database = data.Data.FinalDatabaseName
+	//sc.cfg.Schema = data.Data.FinalSchemaName
+	//sc.cfg.Role = data.Data.FinalRoleName
+	//sc.cfg.Warehouse = data.Data.FinalWarehouseName
+	//sc.populateSessionParameters(data.Data.Parameters)
+
+	//sc.QueryID = data.Data.QueryID
+	//sc.SQLState = data.Data.SQLState
 	return data, err
 }
 

--- a/connection_util.go
+++ b/connection_util.go
@@ -150,7 +150,7 @@ func (sc *snowflakeConn) populateSessionParameters(parameters []nameValueParamet
 			}
 		}
 		logger.Debugf("parameter. name: %v, value: %v", param.Name, v)
-		sc.cfg.Params[strings.ToLower(param.Name)] = &v
+		//sc.cfg.Params[strings.ToLower(param.Name)] = &v
 	}
 }
 

--- a/multistatement.go
+++ b/multistatement.go
@@ -85,7 +85,7 @@ func (sc *snowflakeConn) handleMultiExec(
 	return &snowflakeResult{
 		affectedRows: updatedRows,
 		insertID:     -1,
-		queryID:      sc.QueryID,
+		queryID:      data.QueryID,
 	}, nil
 }
 


### PR DESCRIPTION
Stop using the snowflakeConn to pass the most recent QueryID to the rows
struct that represents the result of the query.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
