### PR TITLE
Snowflake driver to support `WaitForQueryCompletion()`; wait for results to finish without returning result rows 

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -547,7 +547,7 @@ func (sc *snowflakeConn) FetchResult(ctx context.Context, qid string) (driver.Ro
 // given the snowflake query-id. This functionality is not used by the
 // go sql library but is exported to clients who can make use of this
 // capability explicitly.
-func (sc *snowflakeConn) WaitForQueryCompletion(ctx context.Context, qid string) (error) {
+func (sc *snowflakeConn) WaitForQueryCompletion(ctx context.Context, qid string) error {
     return sc.blockOnQueryCompletion(ctx, qid)
 }
 
@@ -560,7 +560,7 @@ func (sc *snowflakeConn) WaitForQueryCompletion(ctx context.Context, qid string)
 // function.
 type ResultFetcher interface {
 	FetchResult(ctx context.Context, qid string) (driver.Rows, error)
-	WaitForQueryCompletion(ctx context.Context, qid string) (error)
+	WaitForQueryCompletion(ctx context.Context, qid string) error
 }
 
 // MonitoringResultFetcher is an interface which allows to fetch monitoringResult

--- a/connection.go
+++ b/connection.go
@@ -560,6 +560,7 @@ func (sc *snowflakeConn) WaitForQueryCompletion(ctx context.Context, qid string)
 // function.
 type ResultFetcher interface {
 	FetchResult(ctx context.Context, qid string) (driver.Rows, error)
+	WaitForQueryCompletion(ctx context.Context, qid string) (error)
 }
 
 // MonitoringResultFetcher is an interface which allows to fetch monitoringResult

--- a/connection.go
+++ b/connection.go
@@ -543,6 +543,14 @@ func (sc *snowflakeConn) FetchResult(ctx context.Context, qid string) (driver.Ro
 	return sc.buildRowsForRunningQuery(ctx, qid)
 }
 
+// WaitForQueryCompletion waits for the result of a previously issued query,
+// given the snowflake query-id. This functionality is not used by the
+// go sql library but is exported to clients who can make use of this
+// capability explicitly.
+func (sc *snowflakeConn) WaitForQueryCompletion(ctx context.Context, qid string) (error) {
+    return sc.blockOnQueryCompletion(ctx, qid)
+}
+
 // ResultFetcher is an interface which allows a query result to be
 // fetched given the corresponding snowflake query-id.
 //

--- a/monitoring.go
+++ b/monitoring.go
@@ -316,7 +316,7 @@ func (sc *snowflakeConn) buildRowsForRunningQuery(
 func (sc *snowflakeConn) blockOnQueryCompletion(
     ctx context.Context,
     qid string,
-) (error) {
+) error {
     if err := sc.blockOnRunningQuery(ctx, qid); err != nil {
         return err
     }


### PR DESCRIPTION
### Description
I need to be able to wait for a query to finish running on the snowflake driver in a way where I'm not affected by the extra latency of building and writing to rows. This way I can block waiting for a query to complete in a non result dependent fashion 

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
