### PR TITLE
Loop for query to complete

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -249,6 +249,7 @@ func (sc *snowflakeConn) waitForCompletedQueryResultResp(
 	for response == nil || isQueryInProgress(response) {
 		deadline, ok := ctx.Deadline()
 		var resp *http.Response
+		// FuncGet will always return either when the query finishes or 45 seconds have passed
 		if !ok {
 			resp, err = sc.rest.FuncGet(ctx, sc.rest, url, headers, sc.rest.RequestTimeout)
 		} else {

--- a/monitoring.go
+++ b/monitoring.go
@@ -265,7 +265,6 @@ func (sc *snowflakeConn) waitForCompletedQueryResultResp(
 			defer func() { _ = resp.Body.Close() }()
 		}
 
-		response := &execResponse{}
 		if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
 			return nil, err
 		}

--- a/monitoring.go
+++ b/monitoring.go
@@ -7,6 +7,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"


### PR DESCRIPTION
### Description

## Why I am making this change: 
The current method I am using to get results deep down calls `FuncGet` which either gives back a result within 45 seconds, or returns. We need to call this function until the query is complete. This will make this have very similar behavior to `getAsync` which waits for the query to complete. The reason I dont want to use getAsync, is because this function builds the sql row object, and populates it. This will add latency, because especially when we use arrow batches, we dont need to do this. Also, even if we don't since the results aren't returned directly by submit async, anyway. We seem to basically be doing this twice. Once when we call exec which calls FuncPostQuery, which calls getAsync, and then we do it again when we call `FetchResult` which also internally calls `buildRowsForRunningQuery` which builds the rows again. 

# Why pull here instead of in multiplex:
Because then callers of `WaitForQueryCompletion` don't have to pull or anything. They just get to wait for query to complete :) 

# Testing: 
I have a workbook with sleep 15s, 1m, 2m and they all work

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
