### PR TITLE
Enable extracting tokens from snowflake conn and constructing TokenAccessor

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -554,7 +554,7 @@ func (sc *snowflakeConn) FetchResult(ctx context.Context, qid string) (driver.Ro
 // go sql library but is exported to clients who can make use of this
 // capability explicitly.
 func (sc *snowflakeConn) WaitForQueryCompletion(ctx context.Context, qid string) error {
-    return sc.blockOnQueryCompletion(ctx, qid)
+	return sc.blockOnQueryCompletion(ctx, qid)
 }
 
 // ResultFetcher is an interface which allows a query result to be
@@ -611,4 +611,15 @@ func (sc *snowflakeConn) SubmitQuerySync(
 	}
 
 	return rows.(*snowflakeRows), nil
+}
+
+// TokenGetter is an interface that can be used to get the current tokens and session
+// ID from a Snowflake connection.
+type TokenGetter interface {
+	GetTokens() (token string, masterToken string, sessionID int64)
+}
+
+func (sc *snowflakeConn) GetTokens() (token string, masterToken string, sessionID int64) {
+	// TODO: If possible, check if the token will expire soon, and refresh it preemptively.
+	return sc.rest.TokenAccessor.GetTokens()
 }

--- a/connection.go
+++ b/connection.go
@@ -614,7 +614,11 @@ func (sc *snowflakeConn) SubmitQuerySync(
 }
 
 // TokenGetter is an interface that can be used to get the current tokens and session
-// ID from a Snowflake connection.
+// ID from a Snowflake connection. This returns the following values:
+//  - token: The temporary credential used to authenticate requests to Snowflake's API.
+//           This is valid for one hour.
+//  - masterToken: Used to refresh the auth token above. Valid for four hours.
+//  - sessionID: The ID of the Snowflake session corresponding to this connection.
 type TokenGetter interface {
 	GetTokens() (token string, masterToken string, sessionID int64)
 }

--- a/dsn.go
+++ b/dsn.go
@@ -391,7 +391,7 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 	return cfg, nil
 }
 
-// Fills missing parameters in the given config.
+// FillMissingConfigParameters fills missing parameters in the given config.
 func FillMissingConfigParameters(cfg *Config) error {
 	return fillMissingConfigParameters(cfg)
 }

--- a/dsn.go
+++ b/dsn.go
@@ -391,6 +391,10 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 	return cfg, nil
 }
 
+func FillMissingConfigParameters(cfg *Config) error {
+	return fillMissingConfigParameters(cfg)
+}
+
 func fillMissingConfigParameters(cfg *Config) error {
 	posDash := strings.LastIndex(cfg.Account, "-")
 	if posDash > 0 {

--- a/dsn.go
+++ b/dsn.go
@@ -391,6 +391,7 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 	return cfg, nil
 }
 
+// Fills missing parameters in the given config.
 func FillMissingConfigParameters(cfg *Config) error {
 	return fillMissingConfigParameters(cfg)
 }

--- a/util.go
+++ b/util.go
@@ -196,6 +196,7 @@ type simpleTokenAccessor struct {
 	tokenLock    sync.RWMutex // Used to synchronize SetTokens and GetTokens
 }
 
+// GetSimpleTokenAccessor returns an empty TokenAccessor.
 func GetSimpleTokenAccessor() TokenAccessor {
 	return getSimpleTokenAccessor()
 }

--- a/util.go
+++ b/util.go
@@ -196,6 +196,10 @@ type simpleTokenAccessor struct {
 	tokenLock    sync.RWMutex // Used to synchronize SetTokens and GetTokens
 }
 
+func GetSimpleTokenAccessor() TokenAccessor {
+	return getSimpleTokenAccessor()
+}
+
 func getSimpleTokenAccessor() TokenAccessor {
 	return &simpleTokenAccessor{sessionID: -1}
 }


### PR DESCRIPTION
### Description
These are some changes to enable getting the token from an active Snowflake
connection. The main change is the addition of the TokenGetter interface.

A couple of other changes needed to make this work:

- Add public constructor for TokenAccessor so we can create a TokenAccessor
  that's pre-populated with credentials from outside of the driver.
- Expose FillMissingConfigParameters, needed to use OpenWithConfig.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
