### PR TITLE
Timeout should always be requestTimeout

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -243,21 +243,11 @@ func (sc *snowflakeConn) waitForCompletedQueryResultResp(
 	}
 	url := sc.rest.getFullURL(resultPath, &param)
 
-
-	deadline, ok := ctx.Deadline()
-	var timeout time.Duration
-	if !ok {
-		timeout = sc.rest.RequestTimeout
-	} else {
-		// if we have a context deadline set we want to override the default
-		timeout = deadline.Sub(time.Now())
-	}
-
 	// internally, pulls on FuncGet until we have a result at the result location (queryID)
 	var response *execResponse
 	var err error
 	for response == nil || isQueryInProgress(response) {
-		response, err = sc.rest.getAsyncOrStatus(ctx, url, headers, timeout)
+		response, err = sc.rest.getAsyncOrStatus(ctx, url, headers, sc.rest.RequestTimeout)
 
 		// if the context is canceled, we have to cancel it manually now
 		if err != nil {


### PR DESCRIPTION
### Description

The reason we are getting the no code error is because of this. The RequestTimeout will always have the correct timeout, this is always what gets passed to FuncGet(). (I tried the previous code with a soon context deadline and it does return nothing from FuncGet, I had thought we would want to preserve the original context deadline, but clearly that is not the case)

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
