### PR TITLE
add panic if funcGet returns nil response or non ok response code 

### DIFF
--- a/async.go
+++ b/async.go
@@ -212,7 +212,7 @@ func (sr *snowflakeRestful) getAsyncOrStatusWithPanic(
 		deadline, ok := ctx.Deadline()
 		statusCode := "nil" 
 		if resp != nil {
-			statusCode = string(resp.StatusCode)
+			statusCode = fmt.Sprint(resp.StatusCode)
 		}
 		panicMessgae := fmt.Sprintf("Deadline set: %t, deadline value: %v, startTime: %v, timeout value: %v, statusCode: %s", ok, deadline, startTime, timeout, statusCode)
 		panic(panicMessgae)

--- a/async.go
+++ b/async.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -195,6 +196,7 @@ func (sr *snowflakeRestful) getAsyncOrStatus(
 }
 
 // if there is no response, from func get, check the timeout and the contextDeadline 
+// and panic to look into the stack trace 
 func (sr *snowflakeRestful) getAsyncOrStatusWithPanic(
 	ctx context.Context,
 	url *url.URL,

--- a/async.go
+++ b/async.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"runtime"
 	"strconv"
 	"time"
 )

--- a/async.go
+++ b/async.go
@@ -185,7 +185,7 @@ func (sr *snowflakeRestful) getAsyncOrStatus(
 	if err != nil {
 		return nil, err
 	}
-	if reportAsyncFromContext(ctx) {
+	if reportAsyncErrorFromContext(ctx) {
 		// if we dont get a response, or we get a bad response, this is not expected, so derive the information to know
 		// why this happened and panic with that message
 		if resp == nil || resp.StatusCode != http.StatusOK {

--- a/async.go
+++ b/async.go
@@ -215,7 +215,7 @@ func (sr *snowflakeRestful) getAsyncOrStatusWithPanic(
 		if resp != nil {
 			statusCode = fmt.Sprint(resp.StatusCode)
 		}
-		panicMessgae := fmt.Sprintf("Deadline set: %t, deadline value: %v, startTime: %v, timeout value: %v, statusCode: %s, stackTrace: ", ok, deadline, startTime, timeout, statusCode, debug.Stack())
+		panicMessgae := fmt.Sprintf("Deadline set: %t, deadline value: %v, startTime: %v, timeout value: %v, statusCode: %s, stackTrace: %s", ok, deadline, startTime, timeout, statusCode, string(debug.Stack()))
 		panic(panicMessgae)
 	}
 	if resp.Body != nil {

--- a/async.go
+++ b/async.go
@@ -189,7 +189,7 @@ func (sr *snowflakeRestful) getAsyncOrStatus(
 		// if we dont get a response, or we get a bad response, this is not expected, so derive the information to know
 		// why this happened and panic with that message
 		if resp == nil || resp.StatusCode != http.StatusOK {
-			panicMessage := getPanicMessage(ctx, resp, startTime, timeout)
+			panicMessage := newPanicMessage(ctx, resp, startTime, timeout)
 			panic(panicMessage)
 		}
 	}

--- a/async.go
+++ b/async.go
@@ -196,7 +196,7 @@ func (sr *snowflakeRestful) getAsyncOrStatus(
 	return response, nil
 }
 
-// panic message for no response
+// panic message for no response from get func
 type panicMessageType = struct {
 	deadlineSet bool
 	deadline    time.Time
@@ -248,6 +248,8 @@ func (sr *snowflakeRestful) getAsyncOrStatusWithPanic(
 		return nil, err
 	}
 
+	// if we dont get a response, or we get a bad response, this is not expected, so derive the information to know
+	// why this happened and panic with that message
 	if resp == nil || resp.StatusCode != http.StatusOK {
 		panicMessage := getPanicMessage(ctx, resp, startTime, timeout)
 		panic(panicMessage)

--- a/async.go
+++ b/async.go
@@ -185,7 +185,7 @@ func (sr *snowflakeRestful) getAsyncOrStatus(
 	if err != nil {
 		return nil, err
 	}
-	if reportAsyncError(ctx) {
+	if reportAsyncFromContext(ctx) {
 		// if we dont get a response, or we get a bad response, this is not expected, so derive the information to know
 		// why this happened and panic with that message
 		if resp == nil || resp.StatusCode != http.StatusOK {

--- a/async.go
+++ b/async.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strconv"
 	"time"
 )
@@ -195,8 +196,8 @@ func (sr *snowflakeRestful) getAsyncOrStatus(
 	return response, nil
 }
 
-// if there is no response, from func get, check the timeout and the contextDeadline 
-// and panic to look into the stack trace 
+// if there is no response, from func get, check the timeout and the contextDeadline
+// and panic to look into the stack trace
 func (sr *snowflakeRestful) getAsyncOrStatusWithPanic(
 	ctx context.Context,
 	url *url.URL,
@@ -210,11 +211,11 @@ func (sr *snowflakeRestful) getAsyncOrStatusWithPanic(
 
 	if resp == nil || resp.StatusCode != http.StatusOK {
 		deadline, ok := ctx.Deadline()
-		statusCode := "nil" 
+		statusCode := "nil"
 		if resp != nil {
 			statusCode = fmt.Sprint(resp.StatusCode)
 		}
-		panicMessgae := fmt.Sprintf("Deadline set: %t, deadline value: %v, startTime: %v, timeout value: %v, statusCode: %s", ok, deadline, startTime, timeout, statusCode)
+		panicMessgae := fmt.Sprintf("Deadline set: %t, deadline value: %v, startTime: %v, timeout value: %v, statusCode: %s, stackTrace: ", ok, deadline, startTime, timeout, statusCode, debug.Stack())
 		panic(panicMessgae)
 	}
 	if resp.Body != nil {

--- a/monitoring.go
+++ b/monitoring.go
@@ -182,7 +182,7 @@ func (sc *snowflakeConn) checkQueryStatus(
 	return &queryRet, nil
 }
 
-// Waits 45 seconds for a query response; return early if query finishes 
+// Waits 45 seconds for a query response; return early if query finishes
 func (sc *snowflakeConn) getQueryResultResp(
 	ctx context.Context,
 	resultPath string,
@@ -247,7 +247,8 @@ func (sc *snowflakeConn) waitForCompletedQueryResultResp(
 	var response *execResponse
 	var err error
 	for response == nil || isQueryInProgress(response) {
-		response, err = sc.rest.getAsyncOrStatusWithPanic(ctx, url, headers, sc.rest.RequestTimeout)
+		ctx = WithReportAsyncError(ctx)
+		response, err = sc.rest.getAsyncOrStatus(ctx, url, headers, sc.rest.RequestTimeout)
 
 		// if the context is canceled, we have to cancel it manually now
 		if err != nil {
@@ -373,13 +374,13 @@ func (sc *snowflakeConn) buildRowsForRunningQuery(
 }
 
 func (sc *snowflakeConn) blockOnQueryCompletion(
-    ctx context.Context,
-    qid string,
+	ctx context.Context,
+	qid string,
 ) error {
-    if err := sc.blockOnRunningQuery(ctx, qid); err != nil {
-        return err
-    }
-    return nil
+	if err := sc.blockOnRunningQuery(ctx, qid); err != nil {
+		return err
+	}
+	return nil
 }
 
 func mkMonitoringFetcher(sc *snowflakeConn, qid string, runtime time.Duration) *monitoringResult {

--- a/monitoring.go
+++ b/monitoring.go
@@ -247,8 +247,7 @@ func (sc *snowflakeConn) waitForCompletedQueryResultResp(
 	var response *execResponse
 	var err error
 	for response == nil || isQueryInProgress(response) {
-		ctx = WithReportAsyncError(ctx)
-		response, err = sc.rest.getAsyncOrStatus(ctx, url, headers, sc.rest.RequestTimeout)
+		response, err = sc.rest.getAsyncOrStatus(WithReportAsyncError(ctx), url, headers, sc.rest.RequestTimeout)
 
 		// if the context is canceled, we have to cancel it manually now
 		if err != nil {

--- a/monitoring.go
+++ b/monitoring.go
@@ -247,7 +247,7 @@ func (sc *snowflakeConn) waitForCompletedQueryResultResp(
 	var response *execResponse
 	var err error
 	for response == nil || isQueryInProgress(response) {
-		response, err = sc.rest.getAsyncOrStatus(ctx, url, headers, sc.rest.RequestTimeout)
+		response, err = sc.rest.getAsyncOrStatusWithPanic(ctx, url, headers, sc.rest.RequestTimeout)
 
 		// if the context is canceled, we have to cancel it manually now
 		if err != nil {

--- a/panic_message.go
+++ b/panic_message.go
@@ -27,7 +27,7 @@ type panicMessageType = struct {
 	stack       *[]uintptr
 }
 
-func getPanicMessage(
+func newPanicMessage(
 	ctx context.Context,
 	resp *http.Response,
 	startTime time.Time,

--- a/panic_message.go
+++ b/panic_message.go
@@ -1,0 +1,57 @@
+package gosnowflake
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+func reportAsyncFromContext(ctx context.Context) bool {
+	val := ctx.Value(reportAsyncError)
+	if val == nil {
+		return false
+	}
+	a, ok := val.(bool)
+	return a && ok
+}
+
+// panic message for no response from get func
+type panicMessageType = struct {
+	deadlineSet bool
+	deadline    time.Time
+	startTime   time.Time
+	timeout     time.Duration
+	statusCode  string
+	stack       *[]uintptr
+}
+
+func getPanicMessage(
+	ctx context.Context,
+	resp *http.Response,
+	startTime time.Time,
+	timeout time.Duration,
+) panicMessageType {
+
+	var pcs [32]uintptr
+	stackEntries := runtime.Callers(1, pcs[:])
+	stackTrace := pcs[0:stackEntries]
+
+	deadline, ok := ctx.Deadline()
+
+	statusCode := "nil"
+	if resp != nil {
+		statusCode = fmt.Sprint(resp.StatusCode)
+	}
+
+	panicMessage := panicMessageType{
+		deadlineSet: ok,
+		deadline:    deadline,
+		startTime:   startTime,
+		timeout:     timeout,
+		statusCode:  statusCode,
+		stack:       &stackTrace,
+	}
+	return panicMessage
+}

--- a/panic_message.go
+++ b/panic_message.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func reportAsyncFromContext(ctx context.Context) bool {
+func reportAsyncErrorFromContext(ctx context.Context) bool {
 	val := ctx.Value(reportAsyncError)
 	if val == nil {
 		return false

--- a/util.go
+++ b/util.go
@@ -26,6 +26,7 @@ const (
 	arrowBatches          contextKey = "ARROW_BATCHES"
 	queryTag              contextKey = "QUERY_TAG"
 	submitSync            contextKey = "SUBMIT_SYNC"
+	reportAsyncError      contextKey = "REPORT_ASYNC_ERROR"
 )
 
 const (
@@ -108,6 +109,12 @@ func WithQueryTag(ctx context.Context, tag string) context.Context {
 // can poll for status using the query ID.
 func WithSubmitSync(ctx context.Context) context.Context {
 	return context.WithValue(ctx, submitSync, true)
+}
+
+// WithReportAsyncError returns a context that enables execution to panic and return
+// any data that could be useful for debugging waitForCompletedQueryResultResp
+func WithReportAsyncError(ctx context.Context) context.Context {
+	return context.WithValue(ctx, reportAsyncError, true)
 }
 
 // Get the request ID from the context if specified, otherwise generate one


### PR DESCRIPTION
## I will use this for my own org and fix & remove before using for SOS 

### Description

In getAsyncOrStatus, if getFunc returns no response, or a response that isnt statusOk, panic and add some helpful variables for tracing.
Variables:
- deadline set (bool)
- deadline value (the time the context will be canceled)
- start time (time when getFunc is called; used to compare deadline or timeout with current time)
- timeout value (value of `sc.rest.RequestTimeout`)
- statusCode ("nil" if there is no response, or string version of the int value)

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [NA] Extended the README / documentation, if necessary
