### PR TITLE
experiment with check status before waitOnComplete

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -555,7 +555,7 @@ func (sc *snowflakeConn) FetchResult(ctx context.Context, qid string) (driver.Ro
 // capability explicitly.
 func (sc *snowflakeConn) WaitForQueryCompletion(ctx context.Context, qid string) error {
 	// if the query is already done, we dont need to wait for it 
-	complete, err := checkIfComplete(ctx, qid) 
+	complete, err := sc.checkIfComplete(ctx, qid) 
 	if complete {
 		return err
 	}

--- a/connection.go
+++ b/connection.go
@@ -554,21 +554,18 @@ func (sc *snowflakeConn) FetchResult(ctx context.Context, qid string) (driver.Ro
 // go sql library but is exported to clients who can make use of this
 // capability explicitly.
 func (sc *snowflakeConn) WaitForQueryCompletion(ctx context.Context, qid string) error {
-	// if the query is already done, we dont need to wait for it 
-	complete, err := sc.checkIfComplete(ctx, qid) 
-	if complete {
+	// if the query is already done, we dont need to wait for it
+	_, err := sc.checkQueryStatus(ctx, qid)
+	// query is complete and has succeeded
+	if err == nil {
+		return nil
+	}
+	// query is complete because of an error; return that error
+	if err.(*SnowflakeError).Number != ErrQueryIsRunning {
 		return err
 	}
+	// query is still running; wait for it to complete
 	return sc.blockOnQueryCompletion(ctx, qid)
-}
-
-func (sc *snowflakeConn) checkIfComplete(ctx context.Context, qid string) (bool, error) {
-	_, err := sc.checkQueryStatus(ctx, qid)
-	if err == nil || err.(*SnowflakeError).Number != ErrQueryIsRunning {
-		// no error means query is complete; error that isnt running means query complete but failed
-		return true, err
-	}
-	return false, nil
 }
 
 // ResultFetcher is an interface which allows a query result to be


### PR DESCRIPTION
### Description
- Experiment to see if this fixes the bug for async, wait, result codepath 

## Why try this:
- snowflake does this check before calling buildRowsForRunningQuery
   - buildRowsForRunningQuery is what my function mimics, but no rows are built
- This will not increase latency 
- At worst this will be a no-op
- since I only see this bug on queries that have already completed AND on these queries, subsequent calls to status succeed... this really could fix it 
  
### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
