### PR TITLE
more logging in submit-async path

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -327,6 +327,9 @@ func (sc *snowflakeConn) blockOnRunningQuery(
 				ok, deadline := ctx.Deadline()
 				logger.WithContext(ctx).Errorf("Deadline: %v, ok: %v", deadline, ok)
 				logger.WithContext(ctx).Errorf("response: %v, error: %v", resp, err)
+				if sc.rest == nil {
+					logger.WithContext(ctx).Errorf("sullSnowflakeRestful")
+				}
 			}
 			return (&SnowflakeError{
 				Number:   code,
@@ -345,6 +348,14 @@ func (sc *snowflakeConn) blockOnRunningQuery(
 			if err != nil {
 				code = ErrQueryStatus
 				message = fmt.Sprintf("%s: (failed to parse original code: %s: %s)", message, resp.Code, err.Error())
+			}
+		}
+		if code == -1 {
+			ok, deadline := ctx.Deadline()
+			logger.WithContext(ctx).Errorf("Deadline: %v, ok: %v", deadline, ok)
+			logger.WithContext(ctx).Errorf("response: %v, error: %v", resp, err)
+			if sc.rest == nil {
+				logger.WithContext(ctx).Errorf("sullSnowflakeRestful")
 			}
 		}
 		return (&SnowflakeError{

--- a/monitoring.go
+++ b/monitoring.go
@@ -325,10 +325,10 @@ func (sc *snowflakeConn) blockOnRunningQuery(
 			}
 			if code == -1 {
 				ok, deadline := ctx.Deadline()
-				logger.WithContext(ctx).Errorf("Deadline: %v, ok: %v", deadline, ok)
-				logger.WithContext(ctx).Errorf("response: %v, error: %v", resp, err)
+				logger.WithContext(ctx).Errorf("deadline: %v, ok: %v, queryId: %v", deadline, ok)
+				logger.WithContext(ctx).Errorf("resp.success: %v, message: %v, error: %v, queryId: %v", resp.Success, resp.Message, err, resp.Data.QueryID)
 				if sc.rest == nil {
-					logger.WithContext(ctx).Errorf("nullSnowflakeRestful")
+					logger.WithContext(ctx).Errorf("sullSnowflakeRestful")
 				}
 			}
 			return (&SnowflakeError{
@@ -352,10 +352,10 @@ func (sc *snowflakeConn) blockOnRunningQuery(
 		}
 		if code == -1 {
 			ok, deadline := ctx.Deadline()
-			logger.WithContext(ctx).Errorf("Deadline: %v, ok: %v", deadline, ok)
-			logger.WithContext(ctx).Errorf("response: %v, error: %v", resp, err)
+			logger.WithContext(ctx).Errorf("deadline: %v, ok: %v, queryId: %v", deadline, ok)
+			logger.WithContext(ctx).Errorf("resp.success: %v, message: %v, error: %v, queryId: %v", resp.Success, resp.Message, err, resp.Data.QueryID)
 			if sc.rest == nil {
-				logger.WithContext(ctx).Errorf("nullSnowflakeRestful")
+				logger.WithContext(ctx).Errorf("sullSnowflakeRestful")
 			}
 		}
 		return (&SnowflakeError{

--- a/monitoring.go
+++ b/monitoring.go
@@ -328,7 +328,7 @@ func (sc *snowflakeConn) blockOnRunningQuery(
 				logger.WithContext(ctx).Errorf("Deadline: %v, ok: %v", deadline, ok)
 				logger.WithContext(ctx).Errorf("response: %v, error: %v", resp, err)
 				if sc.rest == nil {
-					logger.WithContext(ctx).Errorf("sullSnowflakeRestful")
+					logger.WithContext(ctx).Errorf("nullSnowflakeRestful")
 				}
 			}
 			return (&SnowflakeError{
@@ -355,7 +355,7 @@ func (sc *snowflakeConn) blockOnRunningQuery(
 			logger.WithContext(ctx).Errorf("Deadline: %v, ok: %v", deadline, ok)
 			logger.WithContext(ctx).Errorf("response: %v, error: %v", resp, err)
 			if sc.rest == nil {
-				logger.WithContext(ctx).Errorf("sullSnowflakeRestful")
+				logger.WithContext(ctx).Errorf("nullSnowflakeRestful")
 			}
 		}
 		return (&SnowflakeError{

--- a/monitoring.go
+++ b/monitoring.go
@@ -325,7 +325,7 @@ func (sc *snowflakeConn) blockOnRunningQuery(
 			}
 			if code == -1 {
 				ok, deadline := ctx.Deadline()
-				logger.WithContext(ctx).Errorf("deadline: %v, ok: %v, queryId: %v", deadline, ok)
+				logger.WithContext(ctx).Errorf("deadline: %v, ok: %v, queryId: %v", deadline, ok, resp.Data.QueryID)
 				logger.WithContext(ctx).Errorf("resp.success: %v, message: %v, error: %v, queryId: %v", resp.Success, resp.Message, err, resp.Data.QueryID)
 				if sc.rest == nil {
 					logger.WithContext(ctx).Errorf("sullSnowflakeRestful")
@@ -352,7 +352,7 @@ func (sc *snowflakeConn) blockOnRunningQuery(
 		}
 		if code == -1 {
 			ok, deadline := ctx.Deadline()
-			logger.WithContext(ctx).Errorf("deadline: %v, ok: %v, queryId: %v", deadline, ok)
+			logger.WithContext(ctx).Errorf("deadline: %v, ok: %v, queryId: %v", deadline, ok, resp.Data.QueryID)
 			logger.WithContext(ctx).Errorf("resp.success: %v, message: %v, error: %v, queryId: %v", resp.Success, resp.Message, err, resp.Data.QueryID)
 			if sc.rest == nil {
 				logger.WithContext(ctx).Errorf("sullSnowflakeRestful")


### PR DESCRIPTION
### Description
The logging above this shows that the previous code = -1 statement isnt being hit, so we must be here in this non success statement. Also the logs show that for all of the failed requests, the cache isnt being used. I want to know if sc.rest is null (could be a bad connection), and I also still want to know what the response is and what the context deadline is in these cases 