### PR TITLE
Also check the status if the request fails

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -270,6 +270,8 @@ func (sc *snowflakeConn) waitForCompletedQueryResultResp(
 
 	if ! response.Success {
 		logEverything(ctx, qid, response, startTime)
+		_, statusErr := sc.checkQueryStatus(ctx, qid)
+		logger.WithContext(ctx).Errorf("failed queryId: %v, statusErr: %v", qid, statusErr)
 	}
 
 	sc.execRespCache.store(resultPath, response)


### PR DESCRIPTION
### Description
In a further attempt to debug the submitAsync I tagged deadline. The deadline from the context is always 1min+ away. I have tagged whether the context has been canceled. It has not. I also tried to tag the message and the code and there is none. Now I would like to see what the status looks like because nothing else is giving useful information. 
