### PR TITLE
Retry one more time & log response

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -272,6 +272,8 @@ func (sc *snowflakeConn) waitForCompletedQueryResultResp(
 		logEverything(ctx, qid, response, startTime)
 		_, statusErr := sc.checkQueryStatus(ctx, qid)
 		logger.WithContext(ctx).Errorf("failed queryId: %v, statusErr: %v", qid, statusErr)
+		retryResponse, retryErr := sc.rest.getAsyncOrStatus(WithReportAsyncError(ctx), url, headers, sc.rest.RequestTimeout)
+		logger.WithContext(ctx).Errorf("failed queryId: %v, retryResponseSuccess: %v, retryErr: %v", qid, retryResponse.Success, retryErr)
 	}
 
 	sc.execRespCache.store(resultPath, response)


### PR DESCRIPTION
### Description
One more thing to log:
- If I retry, does this work
What I know so far: 
- the context deadline is far from the time that this errors
- the context has not been canceled
- if I run checkQueryStatus, I get status "query complete" so the query itself worked and is ok 
