### PR TITLE
Add StateDuration to QueryMonitoringData struct

### DIFF
--- a/query.go
+++ b/query.go
@@ -145,6 +145,7 @@ type QueryMonitoringData struct {
 	MajorVersionNumber  int              `json:"majorVersionNumber"`
 	MinorVersionNumber  int              `json:"minorVersionNumber"`
 	PatchVersionNumber  int              `json:"patchVersionNumber"`
+	StatesDuration      string           `json:"statesDuration"`
 	Stats               map[string]int64 `json:"stats"`
 }
 


### PR DESCRIPTION
### Description
Added `StatesDuration` field in `QueryMonitoringData` struct. This field contains valuable breakdown of the snowflake query execution time and it is a good idea to keep track of it.