### PR TITLE
add logging for sf cache bug

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -256,6 +256,11 @@ func (sc *snowflakeConn) getQueryResultResp(
 		return nil, err
 	}
 
+	// log when Success is false but body has data
+	if !respd.Success && respd.Code == "" && respd.Message == "" {
+		logger.WithContext(ctx).Errorf("Response body is non-empty but isSuccess is false")
+	}
+
 	// log to get data points for sf to debug cache issue, should log only for staging org
 	if shouldLogSfResponseForCacheBug(ctx) {
 		logHeader, errHeader := json.Marshal(res.Header)

--- a/monitoring.go
+++ b/monitoring.go
@@ -3,10 +3,12 @@
 package gosnowflake
 
 import (
+	"bytes"
 	"context"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"runtime"
 	"strconv"
@@ -194,6 +196,16 @@ func shouldSkipCache(ctx context.Context) bool {
 	return a && ok
 }
 
+// check if we want to log sf response for debugging cache bug
+func shouldLogSfResponseForCacheBug(ctx context.Context) bool {
+	val := ctx.Value(logSfResponseForCacheBug)
+	if val == nil {
+		return false
+	}
+	a, ok := val.(bool)
+	return a && ok
+}
+
 // Waits 45 seconds for a query response; return early if query finishes
 func (sc *snowflakeConn) getQueryResultResp(
 	ctx context.Context,
@@ -228,10 +240,33 @@ func (sc *snowflakeConn) getQueryResultResp(
 		logger.WithContext(ctx).Errorf("failed to get response. err: %v", err)
 		return nil, err
 	}
+	// defer for logging sf cache bug if logging is enabled
+	if res.Body != nil {
+		defer func() { _ = res.Body.Close() }()
+	}
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		logger.WithContext(ctx).Errorf("failed to read bytes from result body. err: %v", err)
+		return nil, err
+	}
+
 	var respd *execResponse
-	if err = json.NewDecoder(res.Body).Decode(&respd); err != nil {
+	if err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&respd); err != nil {
 		logger.WithContext(ctx).Errorf("failed to decode JSON. err: %v", err)
 		return nil, err
+	}
+
+	// log to get data points for sf to debug cache issue, should log only for staging org
+	if shouldLogSfResponseForCacheBug(ctx) {
+		logHeader, errHeader := json.Marshal(res.Header)
+		if errHeader != nil {
+			logger.WithContext(ctx).Errorf("failed to read header from result header. errHeader: %v", errHeader)
+			return nil, errHeader
+		}
+		// log for debugging header and response when Success is false but body has data
+		if !respd.Success && respd.Code == "" && respd.Message == "" {
+			logger.WithContext(ctx).Errorf("failed to build a proper exec response. received body: %s with header %s", string(bodyBytes), string(logHeader))
+		}
 	}
 
 	// if we are skipping the cache, log difference between cached and non cached result

--- a/util.go
+++ b/util.go
@@ -14,20 +14,21 @@ import (
 type contextKey string
 
 const (
-	multiStatementCount   contextKey = "MULTI_STATEMENT_COUNT"
-	asyncMode             contextKey = "ASYNC_MODE_QUERY"
-	asyncModeNoFetch      contextKey = "ASYNC_MODE_NO_FETCH_QUERY"
-	queryIDChannel        contextKey = "QUERY_ID_CHANNEL"
-	snowflakeRequestIDKey contextKey = "SNOWFLAKE_REQUEST_ID"
-	fetchResultByID       contextKey = "SF_FETCH_RESULT_BY_ID"
-	fileStreamFile        contextKey = "STREAMING_PUT_FILE"
-	fileTransferOptions   contextKey = "FILE_TRANSFER_OPTIONS"
-	enableHigherPrecision contextKey = "ENABLE_HIGHER_PRECISION"
-	arrowBatches          contextKey = "ARROW_BATCHES"
-	queryTag              contextKey = "QUERY_TAG"
-	submitSync            contextKey = "SUBMIT_SYNC"
-	reportAsyncError      contextKey = "REPORT_ASYNC_ERROR"
-	skipCache             contextKey = "SKIP_CACHE"
+	multiStatementCount      contextKey = "MULTI_STATEMENT_COUNT"
+	asyncMode                contextKey = "ASYNC_MODE_QUERY"
+	asyncModeNoFetch         contextKey = "ASYNC_MODE_NO_FETCH_QUERY"
+	queryIDChannel           contextKey = "QUERY_ID_CHANNEL"
+	snowflakeRequestIDKey    contextKey = "SNOWFLAKE_REQUEST_ID"
+	fetchResultByID          contextKey = "SF_FETCH_RESULT_BY_ID"
+	fileStreamFile           contextKey = "STREAMING_PUT_FILE"
+	fileTransferOptions      contextKey = "FILE_TRANSFER_OPTIONS"
+	enableHigherPrecision    contextKey = "ENABLE_HIGHER_PRECISION"
+	arrowBatches             contextKey = "ARROW_BATCHES"
+	queryTag                 contextKey = "QUERY_TAG"
+	submitSync               contextKey = "SUBMIT_SYNC"
+	reportAsyncError         contextKey = "REPORT_ASYNC_ERROR"
+	skipCache                contextKey = "SKIP_CACHE"
+	logSfResponseForCacheBug contextKey = "LOG_SF_RESPONSE_FOR_CACHE_BUG"
 )
 
 const (
@@ -119,12 +120,19 @@ func WithReportAsyncError(ctx context.Context) context.Context {
 }
 
 // WithSkipCache returns a context that enables execution to bypass the using the cache
-// in multiplex, this can be set on a per org basis 
+// in multiplex, this can be set on a per org basis
 // *** leave this in on rebase ***
 func WithSkipCache(ctx context.Context) context.Context {
 	return context.WithValue(ctx, skipCache, true)
 }
 
+// WithLogSfResponseForCacheBug returns a context that enables execution to log sf result when success is not true but body is empty
+// this is to help sf debug cache issue
+// in multiplex, this can be set on a per org basis
+// *** leave this in on rebase ***
+func WithLogSfResponseForCacheBug(ctx context.Context) context.Context {
+	return context.WithValue(ctx, logSfResponseForCacheBug, true)
+}
 
 // Get the request ID from the context if specified, otherwise generate one
 func getOrGenerateRequestIDFromContext(ctx context.Context) UUID {


### PR DESCRIPTION
Adding log when snowflake response has isSuccess as false but the response still has a proper body. this is to help snowflake debug the cache issue and provide them any data points if needed. 

mostly un-reverts this PR: https://github.com/sigmacomputing/gosnowflake/pull/109/files
