### PR TITLE
[Feature] Add support for client log context hooks

### DIFF
--- a/ci/build.bat
+++ b/ci/build.bat
@@ -9,7 +9,7 @@ IF !ERRORLEVEL! NEQ 0 go install golang.org/x/lint/golint@latest
 where make2help
 IF !ERRORLEVEL! NEQ 0 go install github.com/Songmu/make2help/cmd/make2help@latest
 where staticcheck
-IF !ERRORLEVEL! NEQ 0 go install honnef.co/go/tools/cmd/staticcheck@latest
+IF !ERRORLEVEL! NEQ 0 go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 
 echo [INFO] Go mod
 go mod tidy

--- a/gosnowflake.mak
+++ b/gosnowflake.mak
@@ -5,7 +5,7 @@ SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 setup:
 	@which golint &> /dev/null  || go install golang.org/x/lint/golint@latest
 	@which make2help &> /dev/null || go install github.com/Songmu/make2help/cmd/make2help@latest
-	@which staticcheck &> /dev/null || go install honnef.co/go/tools/cmd/staticcheck@latest
+	@which staticcheck &> /dev/null || go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 
 ## Install dependencies
 deps: setup

--- a/log.go
+++ b/log.go
@@ -24,6 +24,8 @@ var LogKeys = [...]contextKey{SFSessionIDKey, SFSessionUserKey}
 
 var clientLogContextHooks = map[string]ClientLogContextHook{}
 
+// ClientLogContextHook is a client-defined hook that can be used to insert log
+// fields based on the Context.
 type ClientLogContextHook func(context.Context) interface{}
 
 // RegisterClientLogContextHook registers a hook that can be used to extract fields

--- a/log.go
+++ b/log.go
@@ -13,16 +13,27 @@ import (
 	rlog "github.com/sirupsen/logrus"
 )
 
-//SFSessionIDKey is context key of session id
+// SFSessionIDKey is context key of session id
 const SFSessionIDKey contextKey = "LOG_SESSION_ID"
 
-//SFSessionUserKey is context key of  user id of a session
+// SFSessionUserKey is context key of  user id of a session
 const SFSessionUserKey contextKey = "LOG_USER"
 
-//LogKeys these keys in context should be included in logging messages when using logger.WithContext
+// LogKeys these keys in context should be included in logging messages when using logger.WithContext
 var LogKeys = [...]contextKey{SFSessionIDKey, SFSessionUserKey}
 
-//SFLogger Snowflake logger interface to expose FieldLogger defined in logrus
+var clientLogContextHooks = map[string]ClientLogContextHook{}
+
+type ClientLogContextHook func(context.Context) interface{}
+
+// RegisterClientLogContextHook registers a hook that can be used to extract fields
+// from the Context and associated with log messages using the provided key. This
+// function is not thread-safe and should only be called on startup.
+func RegisterClientLogContextHook(key string, hook ClientLogContextHook) {
+	clientLogContextHooks[key] = hook
+}
+
+// SFLogger Snowflake logger interface to expose FieldLogger defined in logrus
 type SFLogger interface {
 	rlog.Ext1FieldLogger
 	SetLogLevel(level string) error
@@ -30,7 +41,7 @@ type SFLogger interface {
 	SetOutput(output io.Writer)
 }
 
-//SFCallerPrettyfier to provide base file name and function name from calling frame used in SFLogger
+// SFCallerPrettyfier to provide base file name and function name from calling frame used in SFLogger
 func SFCallerPrettyfier(frame *runtime.Frame) (string, string) {
 	return path.Base(frame.Function), fmt.Sprintf("%s:%d", path.Base(frame.File), frame.Line)
 }
@@ -39,7 +50,7 @@ type defaultLogger struct {
 	inner *rlog.Logger
 }
 
-//SetLogLevel set logging level for calling defaultLogger
+// SetLogLevel set logging level for calling defaultLogger
 func (log *defaultLogger) SetLogLevel(level string) error {
 	actualLevel, err := rlog.ParseLevel(level)
 	if err != nil {
@@ -49,13 +60,13 @@ func (log *defaultLogger) SetLogLevel(level string) error {
 	return nil
 }
 
-//WithContext return Entry to include fields in context
+// WithContext return Entry to include fields in context
 func (log *defaultLogger) WithContext(ctx context.Context) *rlog.Entry {
 	fields := context2Fields(ctx)
 	return log.inner.WithFields(*fields)
 }
 
-//CreateDefaultLogger return a new instance of SFLogger with default config
+// CreateDefaultLogger return a new instance of SFLogger with default config
 func CreateDefaultLogger() SFLogger {
 	var rLogger = rlog.New()
 	var formatter = rlog.TextFormatter{CallerPrettyfier: SFCallerPrettyfier}
@@ -311,5 +322,12 @@ func context2Fields(ctx context.Context) *rlog.Fields {
 			fields[string(LogKeys[i])] = ctx.Value(LogKeys[i])
 		}
 	}
+
+	for key, hook := range clientLogContextHooks {
+		if value := hook(ctx); value != nil {
+			fields[key] = value
+		}
+	}
+
 	return &fields
 }


### PR DESCRIPTION
### Description
This change extends the gosnowflake driver's default logging system to support client-defined hooks to extract information from context to insert into log lines. This will specifically be used to add Sigma request IDs to gosnowflake logs. A couple of notes:

1. I took the approach of registering functional hooks instead of having the driver directly extract context keys so that the client can register the hook in one place, rather than having to explicitly set a context key everywhere the driver gets used.
2. The hooks are stored in a global variable (alongside the `LogKeys` that the driver code already defines) that gets accessed in a non-synchronized manner because I intentionally did not want to think about the (potential) performance impact of using `RWMutex` on every logging call. This is fine as long as hooks only get registered once, in the client's `init` function.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
