### PR TITLE
Only cache successful API responses

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -340,7 +340,9 @@ func (sc *snowflakeConn) getQueryResultResp(
 		}
 	}
 
-	sc.execRespCache.store(resultPath, respd)
+	if respd.Success {
+		sc.execRespCache.store(resultPath, respd)
+	}
 	return respd, nil
 }
 

--- a/monitoring.go
+++ b/monitoring.go
@@ -393,11 +393,12 @@ func (sc *snowflakeConn) waitForCompletedQueryResultResp(
 		}
 	}
 
-	if !response.Success {
+	if response.Success {
+		sc.execRespCache.store(resultPath, response)
+	} else {
 		logEverything(ctx, qid, response, startTime)
 	}
 
-	sc.execRespCache.store(resultPath, response)
 	return response, nil
 }
 


### PR DESCRIPTION
### Description

Caching failed responses prevents us from retrying on certain errors that can generally be retried. For example, if we get a "session expired" error, we would like to be able to retry after renewing the session (or creating a new session), rather than always serving a cached response.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
