### PR TITLE
Expose GetChunkMetas() SnowflakeResult to get underlying chunk metadata

### DIFF
--- a/result.go
+++ b/result.go
@@ -22,6 +22,7 @@ type SnowflakeResult interface {
 	GetQueryID() string
 	GetStatus() queryStatus
 	GetArrowBatches() ([]*ArrowBatch, error)
+	GetChunkMetas() ([]execResponseChunk, error)
 	Monitoring(time.Duration) *QueryMonitoringData
 	QueryGraph(time.Duration) *QueryGraphData
 }
@@ -39,6 +40,7 @@ type snowflakeResult struct {
 type monitoringResult struct {
 	monitoringChan <-chan *QueryMonitoringData
 	queryGraphChan <-chan *QueryGraphData
+	// chunkMetas []execResponseChunk
 
 	monitoring *QueryMonitoringData
 	queryGraph *QueryGraphData
@@ -94,6 +96,9 @@ func (res *snowflakeResult) Monitoring(wait time.Duration) *QueryMonitoringData 
 }
 func (res *snowflakeResult) QueryGraph(wait time.Duration) *QueryGraphData {
 	return res.monitoring.QueryGraph(wait)
+}
+func (rows *snowflakeResult) GetChunkMetas() ([]execResponseChunk, error) {
+	return nil, nil
 }
 
 func (m *monitoringResult) Monitoring(wait time.Duration) *QueryMonitoringData {

--- a/result.go
+++ b/result.go
@@ -40,7 +40,6 @@ type snowflakeResult struct {
 type monitoringResult struct {
 	monitoringChan <-chan *QueryMonitoringData
 	queryGraphChan <-chan *QueryGraphData
-	// chunkMetas []execResponseChunk
 
 	monitoring *QueryMonitoringData
 	queryGraph *QueryGraphData

--- a/rows.go
+++ b/rows.go
@@ -191,6 +191,10 @@ func (rows *snowflakeRows) GetArrowBatches() ([]*ArrowBatch, error) {
 	return rows.ChunkDownloader.getArrowBatches(), nil
 }
 
+func (rows *snowflakeRows) GetChunkMetas() ([]execResponseChunk, error) {
+	return rows.ChunkDownloader.getChunkMetas(), nil
+}
+
 func (rows *snowflakeRows) Next(dest []driver.Value) (err error) {
 	if err = rows.waitForAsyncQueryStatus(); err != nil {
 		return err


### PR DESCRIPTION
Expose GetChunkMetas() SnowflakeResult to get underlying chunk metadata, so we know how many chunks SF gives us, what's the chunk size.