### PR TITLE
Add status on snowflakes status result so we know if the query is queued in the warehouse 

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -466,6 +466,7 @@ func (sc *snowflakeConn) GetQueryStatus(
 		queryRet.ErrorMessage,
 		queryRet.Stats.ScanBytes,
 		queryRet.Stats.ProducedRows,
+		queryRet.Status,
 	}, nil
 }
 

--- a/monitoring.go
+++ b/monitoring.go
@@ -116,6 +116,7 @@ type SnowflakeQueryStatus struct {
 	ErrorMessage string
 	ScanBytes    int64
 	ProducedRows int64
+	Status       string
 }
 
 // SnowflakeConnection is a wrapper to snowflakeConn that exposes API functions


### PR DESCRIPTION
### Description
The status response from snowflake only tells us if the query is running or not where running means submitted. If we make this change, when we get the status response from calling getStatus, now we can see if its queued like this:

```
sfStatus, err := x.(gosnowflake.SnowflakeConnection).GetQueryStatus(ctx, resultLocation.Id())

if sfStatus.Status == gosnowflake.SFQueryQueued {
   /// its queued in snowflake! previously we only see running 
}

```

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
