### PR TITLE
return status on snowflake getStatus API (already in master, adding to stable branch)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -458,6 +458,7 @@ func (sc *snowflakeConn) GetQueryStatus(
 		queryRet.ErrorMessage,
 		queryRet.Stats.ScanBytes,
 		queryRet.Stats.ProducedRows,
+		queryRet.Status,
 	}, nil
 }
 

--- a/monitoring.go
+++ b/monitoring.go
@@ -116,6 +116,7 @@ type SnowflakeQueryStatus struct {
 	ErrorMessage string
 	ScanBytes    int64
 	ProducedRows int64
+	Status       string
 }
 
 // SnowflakeConnection is a wrapper to snowflakeConn that exposes API functions


### PR DESCRIPTION
### Description
I made [this](https://github.com/sigmacomputing/gosnowflake/pull/139) change on master instead of on the stable branch. 

The status response from snowflake only tells us if the query is running or not where running means submitted. If we make this change, when we get the status response from calling getStatus, now we can see if its queued like this:

```
sfStatus, err := x.(gosnowflake.SnowflakeConnection).GetQueryStatus(ctx, resultLocation.Id())

if sfStatus.Status == gosnowflake.SFQueryQueued {
   /// its queued in snowflake! previously we only see running 
}

```

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
