### PR TITLE
get rid of url in tracing

### DIFF
--- a/query.go
+++ b/query.go
@@ -42,7 +42,9 @@ type execResponseRowType struct {
 // yifeng: we want to make rebase origin/master easier
 // so create a new struct for export rather than change the original one
 type ExecResponseChunk struct {
-	execResponseChunk
+	RowCount         int   `json:"rowCount"`
+	UncompressedSize int64 `json:"uncompressedSize"`
+	CompressedSize   int64 `json:"compressedSize"`
 }
 
 type execResponseChunk struct {

--- a/rows.go
+++ b/rows.go
@@ -187,7 +187,9 @@ func (rows *snowflakeRows) GetChunkMetas() []ExecResponseChunk {
 	execResponseChunkExport := make([]ExecResponseChunk, len(execResponseChunkPrivate))
 	for i := 0; i < len(execResponseChunkPrivate); i++ {
 		execResponseChunkExport[i] = ExecResponseChunk{
-			execResponseChunkPrivate[i],
+			RowCount:         execResponseChunkPrivate[i].RowCount,
+			UncompressedSize: execResponseChunkPrivate[i].UncompressedSize,
+			CompressedSize:   execResponseChunkPrivate[i].CompressedSize,
 		}
 	}
 	return execResponseChunkExport


### PR DESCRIPTION
We want to get rid of URL field in `execResponseChunk` for tracing, we don't used it anywhere and it has `AWSAccessKeyId` logged, might have security concern. 