### PR TITLE
make `SnowflakeRows` public

### DIFF
--- a/async.go
+++ b/async.go
@@ -28,7 +28,7 @@ func (sr *snowflakeRestful) processAsync(
 	cfg *Config,
 	requestID UUID) (*execResponse, error) {
 	// placeholder object to return to user while retrieving results
-	rows := new(snowflakeRows)
+	rows := new(SnowflakeRows)
 	res := new(snowflakeResult)
 	switch resType := getResultType(ctx); resType {
 	case execResultType:
@@ -57,7 +57,7 @@ func (sr *snowflakeRestful) getAsync(
 	URL *url.URL,
 	timeout time.Duration,
 	res *snowflakeResult,
-	rows *snowflakeRows,
+	rows *SnowflakeRows,
 	requestID UUID,
 	cfg *Config) error {
 	resType := getResultType(ctx)

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -421,7 +421,7 @@ func TestWithArrowBatches(t *testing.T) {
 	defer rows.Close()
 
 	// getting result batches
-	batches, err := rows.(*snowflakeRows).GetArrowBatches()
+	batches, err := rows.(*SnowflakeRows).GetArrowBatches()
 	if err != nil {
 		t.Error(err)
 	}
@@ -503,7 +503,7 @@ func TestWithArrowBatchesAsync(t *testing.T) {
 
 	// getting result batches
 	// this will fail if GetArrowBatches() is not a blocking call
-	batches, err := rows.(*snowflakeRows).GetArrowBatches()
+	batches, err := rows.(*SnowflakeRows).GetArrowBatches()
 	if err != nil {
 		t.Error(err)
 	}

--- a/connection.go
+++ b/connection.go
@@ -369,7 +369,7 @@ func (sc *snowflakeConn) queryContextInternal(
 		return data.Data.AsyncRows, nil
 	}
 
-	rows := new(snowflakeRows)
+	rows := new(SnowflakeRows)
 	rows.sc = sc
 	rows.queryID = sc.QueryID
 	rows.monitoring = mkMonitoringFetcher(sc, sc.QueryID, time.Since(qStart))
@@ -868,7 +868,7 @@ func (sc *snowflakeConn) SubmitQuerySync(
 		return nil, err
 	}
 
-	return rows.(*snowflakeRows), nil
+	return rows.(*SnowflakeRows), nil
 }
 
 // TokenGetter is an interface that can be used to get the current tokens and session

--- a/doc.go
+++ b/doc.go
@@ -247,16 +247,16 @@ data types. The columns are:
 
  1. The SQL data type.
 
- 2. The default Golang data type that is returned when you use snowflakeRows.Scan() to read data from
+ 2. The default Golang data type that is returned when you use SnowflakeRows.Scan() to read data from
     Arrow data format via an interface{}.
 
- 3. The possible Golang data types that can be returned when you use snowflakeRows.Scan() to read data
+ 3. The possible Golang data types that can be returned when you use SnowflakeRows.Scan() to read data
     from Arrow data format directly.
 
- 4. The default Golang data type that is returned when you use snowflakeRows.Scan() to read data from
+ 4. The default Golang data type that is returned when you use SnowflakeRows.Scan() to read data from
     JSON data format via an interface{}. (All returned values are strings.)
 
- 5. The standard Golang data type that is returned when you use snowflakeRows.Scan() to read data from
+ 5. The standard Golang data type that is returned when you use SnowflakeRows.Scan() to read data from
     JSON data format directly.
 
     Go Data Types for Scan()
@@ -299,7 +299,7 @@ data types. The columns are:
     -------------------------------------------------------------------------------------------------------------------
     VARIANT              | string                                      | string
 
-    [1] Converting from a higher precision data type to a lower precision data type via the snowflakeRows.Scan()
+    [1] Converting from a higher precision data type to a lower precision data type via the SnowflakeRows.Scan()
     method can lose low bits (lose precision), lose high bits (completely change the value), or result in error.
 
     [2] Attempting to convert from a higher precision data type to a lower precision data type via interface{}
@@ -308,10 +308,10 @@ data types. The columns are:
     [3] Higher precision data types like *big.Int and *big.Float can be accessed by querying with a context
     returned by WithHigherPrecision().
 
-    [4] You cannot directly Scan() into the alternative data types via snowflakeRows.Scan(), but can convert to
+    [4] You cannot directly Scan() into the alternative data types via SnowflakeRows.Scan(), but can convert to
     those data types by using .Int64()/.String()/.Uint64() methods. For an example, see below.
 
-    [5] You cannot directly Scan() into the alternative data types via snowflakeRows.Scan(), but can convert to
+    [5] You cannot directly Scan() into the alternative data types via SnowflakeRows.Scan(), but can convert to
     those data types by using .Float32()/.String()/.Float64() methods. For an example, see below.
 
 Note: SQL NULL values are converted to Golang nil values, and vice-versa.
@@ -330,7 +330,7 @@ context that enables higher precision must be passed in with the query.
 	var my_interface interface{}
 	var my_big_int_pointer *big.Int
 	var my_int64 int64
-	var rows snowflakeRows
+	var rows SnowflakeRows
 
 	...
 	rows = db.QueryContext(WithHigherPrecision(context.Background), <query>)
@@ -752,24 +752,24 @@ asynchronous mode and synchronous mode.
 		...
 	}
 
-The function db.QueryContext() returns an object of type snowflakeRows
+The function db.QueryContext() returns an object of type SnowflakeRows
 regardless of whether the query is synchronous or asynchronous. However:
 
   - If the query is synchronous, then db.QueryContext() does not return until
     the query has finished and the result set has been loaded into the
-    snowflakeRows object.
+    SnowflakeRows object.
   - If the query is asynchronous, then db.QueryContext() returns a
-    potentially incomplete snowflakeRows object that is filled in later
+    potentially incomplete SnowflakeRows object that is filled in later
     in the background.
 
-The call to the Next() function of snowflakeRows is always synchronous (i.e. blocking).
-If the query has not yet completed and the snowflakeRows object (named "rows" in this
+The call to the Next() function of SnowflakeRows is always synchronous (i.e. blocking).
+If the query has not yet completed and the SnowflakeRows object (named "rows" in this
 example) has not been filled in yet, then rows.Next() waits until the result set has been filled in.
 
-More generally, calls to any Golang SQL API function implemented in snowflakeRows or
+More generally, calls to any Golang SQL API function implemented in SnowflakeRows or
 snowflakeResult are blocking calls, and wait if results are not yet available.
-(Examples of other synchronous calls include: snowflakeRows.Err(), snowflakeRows.Columns(),
-snowflakeRows.columnTypes(), snowflakeRows.Scan(), and snowflakeResult.RowsAffected().)
+(Examples of other synchronous calls include: SnowflakeRows.Err(), SnowflakeRows.Columns(),
+SnowflakeRows.columnTypes(), SnowflakeRows.Scan(), and snowflakeResult.RowsAffected().)
 
 Because the example code above executes only one query and no other activity, there is
 no significant difference in behavior between asynchronous and synchronous behavior.

--- a/monitoring.go
+++ b/monitoring.go
@@ -444,7 +444,7 @@ func logEverything(ctx context.Context, qid string, response *execResponse, star
 // Fetch query result for a query id from /queries/<qid>/result endpoint.
 func (sc *snowflakeConn) rowsForRunningQuery(
 	ctx context.Context, qid string,
-	rows *snowflakeRows) error {
+	rows *SnowflakeRows) error {
 	resultPath := fmt.Sprintf(urlQueriesResultFmt, qid)
 	resp, err := sc.getQueryResultResp(ctx, resultPath)
 	if err != nil {
@@ -548,7 +548,7 @@ func (sc *snowflakeConn) buildRowsForRunningQuery(
 	ctx context.Context,
 	qid string) (
 	driver.Rows, error) {
-	rows := new(snowflakeRows)
+	rows := new(SnowflakeRows)
 	rows.sc = sc
 	rows.queryID = qid
 	if err := sc.rowsForRunningQuery(ctx, qid, rows); err != nil {

--- a/multistatement.go
+++ b/multistatement.go
@@ -98,7 +98,7 @@ func (sc *snowflakeConn) handleMultiExec(
 func (sc *snowflakeConn) handleMultiQuery(
 	ctx context.Context,
 	data execResponseData,
-	rows *snowflakeRows) error {
+	rows *SnowflakeRows) error {
 	if data.ResultIDs == "" {
 		return (&SnowflakeError{
 			Number:   ErrNoResultIDs,

--- a/query.go
+++ b/query.go
@@ -101,7 +101,7 @@ type execResponseData struct {
 
 	// async response placeholders
 	AsyncResult *snowflakeResult `json:"asyncResult,omitempty"`
-	AsyncRows   *snowflakeRows   `json:"asyncRows,omitempty"`
+	AsyncRows   *SnowflakeRows   `json:"asyncRows,omitempty"`
 
 	// file transfer response data
 	UploadInfo              execResponseStageInfo `json:"uploadInfo,omitempty"`

--- a/rows.go
+++ b/rows.go
@@ -36,7 +36,7 @@ type SnowflakeRows interface {
 	GetArrowBatches() ([]*ArrowBatch, error)
 }
 
-type snowflakeRows struct {
+type SnowflakeRows struct {
 	sc                  *snowflakeConn
 	ChunkDownloader     chunkDownloader
 	tailChunkDownloader chunkDownloader
@@ -75,9 +75,9 @@ func (w *wrappedPanic) Error() string {
 	return fmt.Sprintf("Panic within GoSnowflake: %v\nStack-trace:\n %s", w.err, w.stackTrace)
 }
 
-func (rows *snowflakeRows) Close() (err error) {
+func (rows *SnowflakeRows) Close() (err error) {
 	if rows == nil {
-		return fmt.Errorf("Close: nil snowflakeRows")
+		return fmt.Errorf("Close: nil SnowflakeRows")
 	}
 
 	if err := rows.waitForAsyncQueryStatus(); err != nil {
@@ -88,7 +88,7 @@ func (rows *snowflakeRows) Close() (err error) {
 }
 
 // ColumnTypeDatabaseTypeName returns the database column name.
-func (rows *snowflakeRows) ColumnTypeDatabaseTypeName(index int) string {
+func (rows *SnowflakeRows) ColumnTypeDatabaseTypeName(index int) string {
 	if err := rows.waitForAsyncQueryStatus(); err != nil {
 		return err.Error()
 	}
@@ -100,7 +100,7 @@ func (rows *snowflakeRows) ColumnTypeDatabaseTypeName(index int) string {
 }
 
 // ColumnTypeLength returns the length of the column
-func (rows *snowflakeRows) ColumnTypeLength(index int) (length int64, ok bool) {
+func (rows *SnowflakeRows) ColumnTypeLength(index int) (length int64, ok bool) {
 	if err := rows.waitForAsyncQueryStatus(); err != nil || rows.ChunkDownloader == nil {
 		return 0, false
 	}
@@ -114,7 +114,7 @@ func (rows *snowflakeRows) ColumnTypeLength(index int) (length int64, ok bool) {
 	return 0, false
 }
 
-func (rows *snowflakeRows) ColumnTypeNullable(index int) (nullable, ok bool) {
+func (rows *SnowflakeRows) ColumnTypeNullable(index int) (nullable, ok bool) {
 	if err := rows.waitForAsyncQueryStatus(); err != nil || rows.ChunkDownloader == nil {
 		return false, false
 	}
@@ -124,7 +124,7 @@ func (rows *snowflakeRows) ColumnTypeNullable(index int) (nullable, ok bool) {
 	return rows.ChunkDownloader.getRowType()[index].Nullable, true
 }
 
-func (rows *snowflakeRows) ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool) {
+func (rows *SnowflakeRows) ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool) {
 	if err := rows.waitForAsyncQueryStatus(); err != nil || rows.ChunkDownloader == nil {
 		return 0, 0, false
 	}
@@ -143,7 +143,7 @@ func (rows *snowflakeRows) ColumnTypePrecisionScale(index int) (precision, scale
 	return 0, 0, false
 }
 
-func (rows *snowflakeRows) Columns() []string {
+func (rows *SnowflakeRows) Columns() []string {
 	if err := rows.waitForAsyncQueryStatus(); err != nil || rows.ChunkDownloader == nil {
 		return make([]string, 0)
 	}
@@ -155,7 +155,7 @@ func (rows *snowflakeRows) Columns() []string {
 	return ret
 }
 
-func (rows *snowflakeRows) ColumnTypeScanType(index int) reflect.Type {
+func (rows *SnowflakeRows) ColumnTypeScanType(index int) reflect.Type {
 	if err := rows.waitForAsyncQueryStatus(); err != nil || rows.ChunkDownloader == nil {
 		return nil
 	}
@@ -164,24 +164,24 @@ func (rows *snowflakeRows) ColumnTypeScanType(index int) reflect.Type {
 		rows.ChunkDownloader.getRowType()[index].Scale)
 }
 
-func (rows *snowflakeRows) GetQueryID() string {
+func (rows *SnowflakeRows) GetQueryID() string {
 	return rows.queryID
 }
 
-func (rows *snowflakeRows) Monitoring(wait time.Duration) *QueryMonitoringData {
+func (rows *SnowflakeRows) Monitoring(wait time.Duration) *QueryMonitoringData {
 	return rows.monitoring.Monitoring(wait)
 }
 
-func (rows *snowflakeRows) QueryGraph(wait time.Duration) *QueryGraphData {
+func (rows *SnowflakeRows) QueryGraph(wait time.Duration) *QueryGraphData {
 	return rows.monitoring.QueryGraph(wait)
 }
 
-func (rows *snowflakeRows) GetStatus() queryStatus {
+func (rows *SnowflakeRows) GetStatus() queryStatus {
 	return rows.status
 }
 
 // GetArrowBatches returns an array of ArrowBatch objects to retrieve data in arrow.Record format
-func (rows *snowflakeRows) GetArrowBatches() ([]*ArrowBatch, error) {
+func (rows *SnowflakeRows) GetArrowBatches() ([]*ArrowBatch, error) {
 	// Wait for all arrow batches before fetching.
 	// Otherwise, a panic error "invalid memory address or nil pointer dereference" will be thrown.
 	if err := rows.waitForAsyncQueryStatus(); err != nil {
@@ -191,7 +191,7 @@ func (rows *snowflakeRows) GetArrowBatches() ([]*ArrowBatch, error) {
 	return rows.ChunkDownloader.getArrowBatches(), nil
 }
 
-func (rows *snowflakeRows) Next(dest []driver.Value) (err error) {
+func (rows *SnowflakeRows) Next(dest []driver.Value) (err error) {
 	if err = rows.waitForAsyncQueryStatus(); err != nil {
 		return err
 	}
@@ -233,14 +233,14 @@ func (rows *snowflakeRows) Next(dest []driver.Value) (err error) {
 	return err
 }
 
-func (rows *snowflakeRows) HasNextResultSet() bool {
+func (rows *SnowflakeRows) HasNextResultSet() bool {
 	if err := rows.waitForAsyncQueryStatus(); err != nil || rows.ChunkDownloader == nil {
 		return false
 	}
 	return rows.ChunkDownloader.hasNextResultSet()
 }
 
-func (rows *snowflakeRows) NextResultSet() error {
+func (rows *SnowflakeRows) NextResultSet() error {
 	if err := rows.waitForAsyncQueryStatus(); err != nil {
 		return err
 	}
@@ -260,9 +260,9 @@ func (rows *snowflakeRows) NextResultSet() error {
 	return rows.ChunkDownloader.nextResultSet()
 }
 
-func (rows *snowflakeRows) waitForAsyncQueryStatus() error {
+func (rows *SnowflakeRows) waitForAsyncQueryStatus() error {
 	if rows == nil {
-		return fmt.Errorf("waitForAsyncQueryStatus: nil snowflakeRows")
+		return fmt.Errorf("waitForAsyncQueryStatus: nil SnowflakeRows")
 	}
 
 	// if async query, block until query is finished
@@ -280,7 +280,7 @@ func (rows *snowflakeRows) waitForAsyncQueryStatus() error {
 	return nil
 }
 
-func (rows *snowflakeRows) addDownloader(newDL chunkDownloader) {
+func (rows *SnowflakeRows) addDownloader(newDL chunkDownloader) {
 	if rows.ChunkDownloader == nil {
 		rows.ChunkDownloader = newDL
 		rows.tailChunkDownloader = newDL

--- a/rows_test.go
+++ b/rows_test.go
@@ -103,7 +103,7 @@ func TestRowsWithoutChunkDownloader(t *testing.T) {
 		{Name: "c2", ByteLength: 100000, Length: 100000, Type: "TEXT", Scale: 0, Nullable: false},
 	}
 	cm := []execResponseChunk{}
-	rows := new(snowflakeRows)
+	rows := new(SnowflakeRows)
 	rows.sc = nil
 	rows.ChunkDownloader = &snowflakeChunkDownloader{
 		sc:                 nil,
@@ -172,7 +172,7 @@ func TestRowsWithChunkDownloader(t *testing.T) {
 	for i = 0; i < numChunks; i++ {
 		cm = append(cm, execResponseChunk{URL: fmt.Sprintf("dummyURL%v", i+1), RowCount: rowsInChunk})
 	}
-	rows := new(snowflakeRows)
+	rows := new(SnowflakeRows)
 	rows.sc = nil
 	rows.ChunkDownloader = &snowflakeChunkDownloader{
 		sc:            nil,
@@ -251,7 +251,7 @@ func TestRowsWithChunkDownloaderError(t *testing.T) {
 	for i = 0; i < numChunks; i++ {
 		cm = append(cm, execResponseChunk{URL: fmt.Sprintf("dummyURL%v", i+1), RowCount: rowsInChunk})
 	}
-	rows := new(snowflakeRows)
+	rows := new(SnowflakeRows)
 	rows.sc = nil
 	rows.ChunkDownloader = &snowflakeChunkDownloader{
 		sc:            nil,
@@ -329,7 +329,7 @@ func TestRowsWithChunkDownloaderErrorFail(t *testing.T) {
 	for i = 0; i < numChunks; i++ {
 		cm = append(cm, execResponseChunk{URL: fmt.Sprintf("dummyURL%v", i+1), RowCount: rowsInChunk})
 	}
-	rows := new(snowflakeRows)
+	rows := new(SnowflakeRows)
 	rows.sc = nil
 	rows.ChunkDownloader = &snowflakeChunkDownloader{
 		sc:            nil,


### PR DESCRIPTION
### Note
This will also need to be added to the safe branch once approved

### Why is this change being made
In the current multiplex code, rows.Inner() is used to peak into the rows of the specific driver. Since we still want to implement some specific behavior for snowflake (like the ability to get the queryID or monitoring data) we need a way to cast the rows to snowflake rows without using our forked SQL driver before we have time to build our own snowflake driver. Making this public will allow us to cast the rows to snowflake rows. 

### Description
`snowflakeRows` -> `SnowflakeRows`

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
