### PR TITLE
use bigFloat when convert int64 to float

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -965,20 +965,18 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 				defer newCol.Release()
 			} else if srcColumnMeta.Scale != 0 && col.DataType().ID() == arrow.INT64 {
 				// gosnowflake driver uses compute.Divide() which could bring `integer value not in range: -9007199254740992 to 9007199254740992` error
-				// before we figure this out, we can convert to arrow.Decimal and follow the same code path as above.
+				// if we convert int64 to BigDecimal and then use compute.CastArray to convert BigDecimal to float64, we won't have enough precision.
+				// e.g 0.1 as (38,19) will result 0.09999999999999999
 				values := col.(*array.Int64).Int64Values()
-				decimalValues := make([]decimal128.Num, len(values))
+				floatValues := make([]float64, len(values))
+
 				for i, val := range values {
-					decimalValues[i] = decimal128.FromI64(val)
+					floatValues[i], _ = intToBigFloat(val, srcColumnMeta.Scale).Float64()
 				}
-				builder := array.NewDecimal128Builder(memory.NewCheckedAllocator(memory.NewGoAllocator()), &arrow.Decimal128Type{Precision: int32(srcColumnMeta.Precision), Scale: int32(srcColumnMeta.Scale)})
-				builder.AppendValues(decimalValues, nil)
-				decimalArray := builder.NewArray()
+				builder := array.NewFloat64Builder(memory.NewCheckedAllocator(memory.NewGoAllocator()))
+				builder.AppendValues(floatValues, nil)
+				newCol := builder.NewArray()
 				builder.Release()
-				newCol, err = compute.CastArray(ctx, decimalArray, compute.UnsafeCastOptions(arrow.PrimitiveTypes.Float64))
-				if err != nil {
-					return nil, err
-				}
 				defer newCol.Release()
 			}
 		case timeType:

--- a/converter.go
+++ b/converter.go
@@ -975,7 +975,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 				}
 				builder := array.NewFloat64Builder(memory.NewCheckedAllocator(memory.NewGoAllocator()))
 				builder.AppendValues(floatValues, nil)
-				newCol := builder.NewArray()
+				newCol = builder.NewArray()
 				builder.Release()
 				defer newCol.Release()
 			}

--- a/converter_test.go
+++ b/converter_test.go
@@ -834,7 +834,7 @@ func TestArrowToRecord(t *testing.T) {
 		{
 			logical:  "fixed",
 			physical: "float64",
-			rowType:  execResponseRowType{Precision: 38, Scale: 5},
+			rowType:  execResponseRowType{Scale: 5},
 			sc:       arrow.NewSchema([]arrow.Field{{Type: &arrow.Int64Type{}}}, nil),
 			values:   []int64{12345, 234567},
 			nrows:    2,
@@ -843,7 +843,7 @@ func TestArrowToRecord(t *testing.T) {
 			compare: func(src interface{}, convertedRec arrow.Record) int {
 				srcvs := src.([]int64)
 				for i, f := range convertedRec.Column(0).(*array.Float64).Float64Values() {
-					rawFloat := float64(srcvs[i]) / 1e5
+					rawFloat, _ := intToBigFloat(srcvs[i], 5).Float64()
 					if rawFloat != f {
 						return i
 					}


### PR DESCRIPTION
Follow #149. 

In #149  we converted int64 to BigDecimal and then use `compute.CastArray` to convert BigDecimal to float64, however we won't have enough precision. e.g in input table 0.1 as (38,19) will result 0.09999999999999999.

In this PR we use big.Float to have more precision. 

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
