### PR TITLE
[SIG-40455] fix arrow batch int64 to ntz/ltz

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -1038,7 +1038,9 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 			} else if col.DataType().ID() == arrow.INT64 {
 				for i, t := range col.(*array.Int64).Int64Values() {
 					if !col.IsNull(i) {
-						val := time.Unix(0, t*int64(math.Pow10(9-int(srcColumnMeta.Scale)))).UTC()
+						q := t / int64(math.Pow10(int(srcColumnMeta.Scale)))
+						r := t % int64(math.Pow10(int(srcColumnMeta.Scale)))
+						val := time.Unix(q, r)
 						tb.Append(arrow.Timestamp(val.UnixNano()))
 					} else {
 						tb.AppendNull()

--- a/converter.go
+++ b/converter.go
@@ -999,6 +999,15 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 						tb.AppendNull()
 					}
 				}
+			} else if col.DataType().ID() == arrow.INT64 {
+				for i, t := range col.(*array.Int64).Int64Values() {
+					if !col.IsNull(i) {
+						val := time.Unix(0, t*int64(math.Pow10(9-int(srcColumnMeta.Scale)))).UTC()
+						tb.Append(arrow.Timestamp(val.UnixNano()))
+					} else {
+						tb.AppendNull()
+					}
+				}
 			} else {
 				for i, t := range col.(*array.Timestamp).TimestampValues() {
 					if !col.IsNull(i) {
@@ -1021,6 +1030,15 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 				for i := 0; i < int(numRows); i++ {
 					if !col.IsNull(i) {
 						val := time.Unix(epoch[i], int64(fraction[i]))
+						tb.Append(arrow.Timestamp(val.UnixNano()))
+					} else {
+						tb.AppendNull()
+					}
+				}
+			} else if col.DataType().ID() == arrow.INT64 {
+				for i, t := range col.(*array.Int64).Int64Values() {
+					if !col.IsNull(i) {
+						val := time.Unix(0, t*int64(math.Pow10(9-int(srcColumnMeta.Scale)))).UTC()
 						tb.Append(arrow.Timestamp(val.UnixNano()))
 					} else {
 						tb.AppendNull()

--- a/converter_test.go
+++ b/converter_test.go
@@ -942,6 +942,29 @@ func TestArrowToRecord(t *testing.T) {
 			},
 		},
 		{
+			logical:  "timestamp_ntz",
+			physical: "int64",
+			values:   []time.Time{time.Now(), localTime},
+			nrows:    2,
+			rowType:  execResponseRowType{Scale: 9},
+			sc:       arrow.NewSchema([]arrow.Field{{Type: &arrow.Int64Type{}}}, nil),
+			builder:  array.NewInt64Builder(pool),
+			append: func(b array.Builder, vs interface{}) {
+				for _, t := range vs.([]time.Time) {
+					b.(*array.Int64Builder).Append(t.UnixNano())
+				}
+			},
+			compare: func(src interface{}, convertedRec arrow.Record) int {
+				srcvs := src.([]time.Time)
+				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
+					if srcvs[i].UnixNano() != int64(t) {
+						return i
+					}
+				}
+				return -1
+			},
+		},
+		{
 			logical: "timestamp_ltz",
 			values:  []time.Time{time.Now(), localTime},
 			nrows:   2,


### PR DESCRIPTION
Fix https://sigma-computing.sentry.io/issues/4369020647
`panic: interface conversion: arrow.Array is *array.Int64, not *array.Timestamp`
sometimes snowflake sends us int64 array and we want to interpret as timestamp. 
underlying array.Timestamp is just int64.

