### PR TITLE
[SIG-40738] convert binary array to string array

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -978,6 +978,12 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 				newCol = builder.NewArray()
 				builder.Release()
 				defer newCol.Release()
+			} else if col.DataType().ID() == arrow.BINARY {
+				newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.BinaryTypes.String))
+				if err != nil {
+					return nil, err
+				}
+				defer newCol.Release()
 			}
 		case timeType:
 			newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.FixedWidthTypes.Time64ns))

--- a/converter_test.go
+++ b/converter_test.go
@@ -886,6 +886,17 @@ func TestArrowToRecord(t *testing.T) {
 			append:  func(b array.Builder, vs interface{}) { b.(*array.BinaryBuilder).AppendValues(vs.([][]byte), valids) },
 		},
 		{
+			logical: "non utf-8 binary",
+			sc:      arrow.NewSchema([]arrow.Field{{Type: &arrow.BinaryType{}}}, nil),
+			values: [][]byte{
+				{0x80, 0x81, 0x82},
+				{0xF0, 0xF1, 0xF2},
+			},
+			nrows:   2,
+			builder: array.NewBinaryBuilder(pool, arrow.BinaryTypes.Binary),
+			append:  func(b array.Builder, vs interface{}) { b.(*array.BinaryBuilder).AppendValues(vs.([][]byte), valids) },
+		},
+		{
 			logical: "date",
 			sc:      arrow.NewSchema([]arrow.Field{{Type: &arrow.Date32Type{}}}, nil),
 			values:  []time.Time{time.Now(), localTime},

--- a/converter_test.go
+++ b/converter_test.go
@@ -889,8 +889,8 @@ func TestArrowToRecord(t *testing.T) {
 			logical: "non utf-8 binary",
 			sc:      arrow.NewSchema([]arrow.Field{{Type: &arrow.BinaryType{}}}, nil),
 			values: [][]byte{
-				{0x80, 0x81, 0x82},
-				{0xF0, 0xF1, 0xF2},
+				{0x8F},
+				{0x9F},
 			},
 			nrows:   2,
 			builder: array.NewBinaryBuilder(pool, arrow.BinaryTypes.Binary),


### PR DESCRIPTION
We've seen sentry error on staging when arrow batch is enabled

 https://sigma-computing.sentry.io/issues/4381126171/?alert_rule_id=10811375&alert_type=issue&project=6305692&referrer=slack




error is thrown here
```
                // ArrayType, VariantType, ObjectType, etc...
                (_, Variant, DataType::Utf8 | DataType::Binary) => {
                    let c = Column::Json(StringArray::from(a.data().clone()));
                    Ok((Variant, c))
                }

```

caused by 

<img width="649" alt="image" src="https://github.com/sigmacomputing/gosnowflake/assets/86254270/1290fb49-a623-4764-b846-b72485fac008">

in QLC stack we only support string array. We have to convert non-UTF8 to string array.
