### PR TITLE
Revert "[SIG-40738] convert binary array to string array"

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -1045,12 +1045,6 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 				newCol = builder.NewArray()
 				builder.Release()
 				defer newCol.Release()
-			} else if col.DataType().ID() == arrow.BINARY {
-				newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.BinaryTypes.String))
-				if err != nil {
-					return nil, err
-				}
-				defer newCol.Release()
 			}
 		case timeType:
 			newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.FixedWidthTypes.Time64ns))

--- a/converter_test.go
+++ b/converter_test.go
@@ -886,17 +886,6 @@ func TestArrowToRecord(t *testing.T) {
 			append:  func(b array.Builder, vs interface{}) { b.(*array.BinaryBuilder).AppendValues(vs.([][]byte), valids) },
 		},
 		{
-			logical: "non utf-8 binary",
-			sc:      arrow.NewSchema([]arrow.Field{{Type: &arrow.BinaryType{}}}, nil),
-			values: [][]byte{
-				{0x8F},
-				{0x9F},
-			},
-			nrows:   2,
-			builder: array.NewBinaryBuilder(pool, arrow.BinaryTypes.Binary),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.BinaryBuilder).AppendValues(vs.([][]byte), valids) },
-		},
-		{
 			logical: "date",
 			sc:      arrow.NewSchema([]arrow.Field{{Type: &arrow.Date32Type{}}}, nil),
 			values:  []time.Time{time.Now(), localTime},


### PR DESCRIPTION
Reverts sigmacomputing/gosnowflake#153

The original solution is incorrect, it's a no-op, since `arrow.Binary` won't be under `case fixedType:`
I tried to do it under the correct place, but got 
`LEAK of 64 bytes FROM github.com/apache/arrow/go/v12/arrow/compute/internal/exec.(*KernelCtx).Allocate line 84`
when casting binary to string using 	

`newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.BinaryTypes.String)) `

Let's revert the code for now. 