### PR TITLE
Set log level to "debug"

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -32,7 +32,7 @@ func (d SnowflakeDriver) OpenWithConfig(
 	config Config) (
 	driver.Conn, error) {
 	if config.Tracing != "" {
-		logger.SetLogLevel(config.Tracing)
+		logger.SetLogLevel("debug")
 	}
 	logger.Info("OpenWithConfig")
 	sc, err := buildSnowflakeConn(ctx, config)


### PR DESCRIPTION
set the log level to debug

See [here](https://community.snowflake.com/s/article/How-to-generate-log-file-on-Snowflake-connectors#Go:~:text=In%20order%20to%20enable%20debug%20logging%20for%20the%20driver%2C%20user%20could%20use%20SetLogLevel(%22debug%22)%20in%20SFLogger%20interface.%C2%A0%C2%A0%0ATo%20redirect%20the%20logs%20SFlogger.SetOutput%20method%20could%20do%20the%20work.) for why I did this 

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
