### PR TITLE
rename registration name in fork so we can run both forked and non forked

### DIFF
--- a/benchmark/jsonresultset/jsonresultset_test.go
+++ b/benchmark/jsonresultset/jsonresultset_test.go
@@ -108,7 +108,7 @@ func runJSONResultSet() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	defer db.Close()
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)

--- a/benchmark/jsonresultset/jsonresultset_test.go
+++ b/benchmark/jsonresultset/jsonresultset_test.go
@@ -108,7 +108,7 @@ func runJSONResultSet() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	defer db.Close()
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)

--- a/benchmark/largesetresult/largesetresult_test.go
+++ b/benchmark/largesetresult/largesetresult_test.go
@@ -91,7 +91,7 @@ func runLargeResultSet() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	defer db.Close()
 	if err != nil {
 		log.Fatalf("failed to connect. err: %v", err)

--- a/benchmark/largesetresult/largesetresult_test.go
+++ b/benchmark/largesetresult/largesetresult_test.go
@@ -91,7 +91,7 @@ func runLargeResultSet() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	defer db.Close()
 	if err != nil {
 		log.Fatalf("failed to connect. err: %v", err)

--- a/cmd/externalbrowser/externalbrowser.go
+++ b/cmd/externalbrowser/externalbrowser.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	// The external browser flow should start with the call to Open
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/externalbrowser/externalbrowser.go
+++ b/cmd/externalbrowser/externalbrowser.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	// The external browser flow should start with the call to Open
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/keepalive/keepalive.go
+++ b/cmd/keepalive/keepalive.go
@@ -89,7 +89,7 @@ func main() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/keepalive/keepalive.go
+++ b/cmd/keepalive/keepalive.go
@@ -89,7 +89,7 @@ func main() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/keypair/keypair.go
+++ b/cmd/keypair/keypair.go
@@ -84,7 +84,7 @@ func main() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/keypair/keypair.go
+++ b/cmd/keypair/keypair.go
@@ -84,7 +84,7 @@ func main() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/mfa/mfa.go
+++ b/cmd/mfa/mfa.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	// The external browser flow should start with the call to Open
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/mfa/mfa.go
+++ b/cmd/mfa/mfa.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	// The external browser flow should start with the call to Open
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/noconnpool/noconnpool.go
+++ b/cmd/noconnpool/noconnpool.go
@@ -62,7 +62,7 @@ func main() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. err: %v", err)
 	}

--- a/cmd/noconnpool/noconnpool.go
+++ b/cmd/noconnpool/noconnpool.go
@@ -62,7 +62,7 @@ func main() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. err: %v", err)
 	}

--- a/cmd/oauth/oauth.go
+++ b/cmd/oauth/oauth.go
@@ -35,7 +35,7 @@ func main() {
 	escapedToken := url.QueryEscape(token)
 
 	dsn := fmt.Sprintf("%v?authenticator=OAUTH&token=%v", account, escapedToken)
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/oauth/oauth.go
+++ b/cmd/oauth/oauth.go
@@ -35,7 +35,7 @@ func main() {
 	escapedToken := url.QueryEscape(token)
 
 	dsn := fmt.Sprintf("%v?authenticator=OAUTH&token=%v", account, escapedToken)
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/select1/select1.go
+++ b/cmd/select1/select1.go
@@ -66,7 +66,7 @@ func main() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/select1/select1.go
+++ b/cmd/select1/select1.go
@@ -66,7 +66,7 @@ func main() {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
 
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}

--- a/cmd/selectmany/selectmany.go
+++ b/cmd/selectmany/selectmany.go
@@ -78,7 +78,7 @@ func run(dsn string) {
 		}
 	}()
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. err: %v", err)
 	}

--- a/cmd/selectmany/selectmany.go
+++ b/cmd/selectmany/selectmany.go
@@ -78,7 +78,7 @@ func run(dsn string) {
 		}
 	}()
 
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. err: %v", err)
 	}

--- a/cmd/showparam/showparam.go
+++ b/cmd/showparam/showparam.go
@@ -65,7 +65,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. err: %v", err)
 	}

--- a/cmd/showparam/showparam.go
+++ b/cmd/showparam/showparam.go
@@ -65,7 +65,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
 	}
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. err: %v", err)
 	}

--- a/doc.go
+++ b/doc.go
@@ -10,7 +10,7 @@ Clients can use the database/sql package directly. For example:
 	)
 
 	func main() {
-		db, err := sql.Open("snowflake", "user:password@my_organization-my_account/mydb")
+		db, err := sql.Open("sigmacomputing/gosnowflake", "user:password@my_organization-my_account/mydb")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -22,7 +22,7 @@ Clients can use the database/sql package directly. For example:
 
 Use the Open() function to create a database handle with connection parameters:
 
-	db, err := sql.Open("snowflake", "<connection string>")
+	db, err := sql.Open("sigmacomputing/gosnowflake", "<connection string>")
 
 The Go Snowflake Driver supports the following connection syntaxes (or data source name (DSN) formats):
 
@@ -40,7 +40,7 @@ named "my_account" under the organization named "my_organization",
 where the username is "jsmith", password is "mypassword", database is "mydb",
 schema is "testschema", and warehouse is "mywh":
 
-	db, err := sql.Open("snowflake", "jsmith:mypassword@my_organization-my_account/mydb/testschema?warehouse=mywh")
+	db, err := sql.Open("sigmacomputing/gosnowflake", "jsmith:mypassword@my_organization-my_account/mydb/testschema?warehouse=mywh")
 
 # Connection Parameters
 

--- a/doc.go
+++ b/doc.go
@@ -10,7 +10,7 @@ Clients can use the database/sql package directly. For example:
 	)
 
 	func main() {
-		db, err := sql.Open("sigmacomputing/gosnowflake", "user:password@my_organization-my_account/mydb")
+		db, err := sql.Open("sigmacomputing+gosnowflake", "user:password@my_organization-my_account/mydb")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -22,7 +22,7 @@ Clients can use the database/sql package directly. For example:
 
 Use the Open() function to create a database handle with connection parameters:
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", "<connection string>")
+	db, err := sql.Open("sigmacomputing+gosnowflake", "<connection string>")
 
 The Go Snowflake Driver supports the following connection syntaxes (or data source name (DSN) formats):
 
@@ -40,7 +40,7 @@ named "my_account" under the organization named "my_organization",
 where the username is "jsmith", password is "mypassword", database is "mydb",
 schema is "testschema", and warehouse is "mywh":
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", "jsmith:mypassword@my_organization-my_account/mydb/testschema?warehouse=mywh")
+	db, err := sql.Open("sigmacomputing+gosnowflake", "jsmith:mypassword@my_organization-my_account/mydb/testschema?warehouse=mywh")
 
 # Connection Parameters
 

--- a/driver.go
+++ b/driver.go
@@ -57,7 +57,7 @@ func runningOnGithubAction() bool {
 var logger = CreateDefaultLogger()
 
 func init() {
-	sql.Register("sigmacomputing/gosnowflake", &SnowflakeDriver{})
+	sql.Register("sigmacomputing+gosnowflake", &SnowflakeDriver{})
 	logger.SetLogLevel("error")
 	if runningOnGithubAction() {
 		logger.SetLogLevel("fatal")

--- a/driver.go
+++ b/driver.go
@@ -57,7 +57,7 @@ func runningOnGithubAction() bool {
 var logger = CreateDefaultLogger()
 
 func init() {
-	sql.Register("snowflake", &SnowflakeDriver{})
+	sql.Register("sigmacomputing/gosnowflake", &SnowflakeDriver{})
 	logger.SetLogLevel("error")
 	if runningOnGithubAction() {
 		logger.SetLogLevel("fatal")

--- a/driver_ocsp_test.go
+++ b/driver_ocsp_test.go
@@ -72,7 +72,7 @@ func TestOCSPFailOpen(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -110,7 +110,7 @@ func TestOCSPFailOpenWithoutFileCache(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -149,7 +149,7 @@ func TestOCSPFailOpenValidityError(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -188,7 +188,7 @@ func TestOCSPFailClosedValidityError(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -232,7 +232,7 @@ func TestOCSPFailOpenUnknownStatus(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -271,7 +271,7 @@ func TestOCSPFailClosedUnknownStatus(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -316,7 +316,7 @@ func TestOCSPFailOpenRevokedStatus(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -361,7 +361,7 @@ func TestOCSPFailClosedRevokedStatus(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -405,7 +405,7 @@ func TestOCSPFailOpenCacheServerTimeout(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -444,7 +444,7 @@ func TestOCSPFailClosedCacheServerTimeout(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -500,7 +500,7 @@ func TestOCSPFailOpenResponderTimeout(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -540,7 +540,7 @@ func TestOCSPFailClosedResponderTimeout(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -583,7 +583,7 @@ func TestOCSPFailOpenResponder404(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -622,7 +622,7 @@ func TestOCSPFailClosedResponder404(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -659,7 +659,7 @@ func TestExpiredCertificate(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -705,7 +705,7 @@ func TestSelfSignedCertificate(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -746,7 +746,7 @@ func TestOCSPFailOpenNoOCSPURL(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -785,7 +785,7 @@ func TestOCSPFailClosedNoOCSPURL(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()

--- a/driver_ocsp_test.go
+++ b/driver_ocsp_test.go
@@ -72,7 +72,7 @@ func TestOCSPFailOpen(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -110,7 +110,7 @@ func TestOCSPFailOpenWithoutFileCache(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -149,7 +149,7 @@ func TestOCSPFailOpenValidityError(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -188,7 +188,7 @@ func TestOCSPFailClosedValidityError(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -232,7 +232,7 @@ func TestOCSPFailOpenUnknownStatus(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -271,7 +271,7 @@ func TestOCSPFailClosedUnknownStatus(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -316,7 +316,7 @@ func TestOCSPFailOpenRevokedStatus(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -361,7 +361,7 @@ func TestOCSPFailClosedRevokedStatus(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -405,7 +405,7 @@ func TestOCSPFailOpenCacheServerTimeout(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -444,7 +444,7 @@ func TestOCSPFailClosedCacheServerTimeout(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -500,7 +500,7 @@ func TestOCSPFailOpenResponderTimeout(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -540,7 +540,7 @@ func TestOCSPFailClosedResponderTimeout(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -583,7 +583,7 @@ func TestOCSPFailOpenResponder404(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -622,7 +622,7 @@ func TestOCSPFailClosedResponder404(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -659,7 +659,7 @@ func TestExpiredCertificate(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -705,7 +705,7 @@ func TestSelfSignedCertificate(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -746,7 +746,7 @@ func TestOCSPFailOpenNoOCSPURL(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()
@@ -785,7 +785,7 @@ func TestOCSPFailClosedNoOCSPURL(t *testing.T) {
 		t.Fatalf("failed to build URL from Config: %v", config)
 	}
 
-	if db, err = sql.Open("snowflake", testURL); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", testURL); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", testURL, err)
 	}
 	defer db.Close()

--- a/driver_test.go
+++ b/driver_test.go
@@ -119,7 +119,7 @@ func setup() (string, error) {
 	}
 	var db *sql.DB
 	var err error
-	if db, err = sql.Open("snowflake", dsn); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", dsn); err != nil {
 		return "", fmt.Errorf("failed to open db. err: %v", err)
 	}
 	defer db.Close()
@@ -134,7 +134,7 @@ func setup() (string, error) {
 func teardown() error {
 	var db *sql.DB
 	var err error
-	if db, err = sql.Open("snowflake", dsn); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", dsn); err != nil {
 		return fmt.Errorf("failed to open db. %v, err: %v", dsn, err)
 	}
 	defer db.Close()
@@ -312,7 +312,7 @@ func (dbt *DBTest) mustPrepare(query string) (stmt *sql.Stmt) {
 }
 
 func runTests(t *testing.T, dsn string, tests ...func(dbt *DBTest)) {
-	db, err := sql.Open("snowflake", dsn)
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
 	if err != nil {
 		t.Fatalf("error connecting: %s", err.Error())
 	}
@@ -353,7 +353,7 @@ func invalidUserPassErrorTests(invalidDNS string, t *testing.T) {
 		parameters.Add("account", account)
 	}
 	invalidDNS += "?" + parameters.Encode()
-	db, err := sql.Open("snowflake", invalidDNS)
+	db, err := sql.Open("sigmacomputing/gosnowflake", invalidDNS)
 	if err != nil {
 		t.Fatalf("error creating a connection object: %s", err.Error())
 	}
@@ -391,7 +391,7 @@ func invalidHostErrorTests(invalidDNS string, mstr []string, t *testing.T) {
 	}
 	parameters.Add("loginTimeout", "10")
 	invalidDNS += "?" + parameters.Encode()
-	db, err := sql.Open("snowflake", invalidDNS)
+	db, err := sql.Open("sigmacomputing/gosnowflake", invalidDNS)
 	if err != nil {
 		t.Fatalf("error creating a connection object: %s", err.Error())
 	}
@@ -1480,7 +1480,7 @@ func TestValidateDatabaseParameter(t *testing.T) {
 			parameters.Add(k, v)
 		}
 		newDSN += "?" + parameters.Encode()
-		db, err := sql.Open("snowflake", newDSN)
+		db, err := sql.Open("sigmacomputing/gosnowflake", newDSN)
 		// actual connection won't happen until run a query
 		if err != nil {
 			t.Fatalf("error creating a connection object: %s", err.Error())
@@ -1509,7 +1509,7 @@ func TestSpecifyWarehouseDatabase(t *testing.T) {
 	if protocol != "" {
 		parameters.Add("protocol", protocol)
 	}
-	db, err := sql.Open("snowflake", dsn+"?"+parameters.Encode())
+	db, err := sql.Open("sigmacomputing/gosnowflake", dsn+"?"+parameters.Encode())
 	if err != nil {
 		t.Fatalf("error creating a connection object: %s", err.Error())
 	}
@@ -1552,7 +1552,7 @@ func TestPingInvalidHost(t *testing.T) {
 		t.Fatalf("failed to parse config. config: %v, err: %v", config, err)
 	}
 
-	db, err := sql.Open("snowflake", testURL)
+	db, err := sql.Open("sigmacomputing/gosnowflake", testURL)
 	if err != nil {
 		t.Fatalf("failed to initalize the connetion. err: %v", err)
 	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -119,7 +119,7 @@ func setup() (string, error) {
 	}
 	var db *sql.DB
 	var err error
-	if db, err = sql.Open("sigmacomputing/gosnowflake", dsn); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", dsn); err != nil {
 		return "", fmt.Errorf("failed to open db. err: %v", err)
 	}
 	defer db.Close()
@@ -134,7 +134,7 @@ func setup() (string, error) {
 func teardown() error {
 	var db *sql.DB
 	var err error
-	if db, err = sql.Open("sigmacomputing/gosnowflake", dsn); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", dsn); err != nil {
 		return fmt.Errorf("failed to open db. %v, err: %v", dsn, err)
 	}
 	defer db.Close()
@@ -312,7 +312,7 @@ func (dbt *DBTest) mustPrepare(query string) (stmt *sql.Stmt) {
 }
 
 func runTests(t *testing.T, dsn string, tests ...func(dbt *DBTest)) {
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn)
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn)
 	if err != nil {
 		t.Fatalf("error connecting: %s", err.Error())
 	}
@@ -353,7 +353,7 @@ func invalidUserPassErrorTests(invalidDNS string, t *testing.T) {
 		parameters.Add("account", account)
 	}
 	invalidDNS += "?" + parameters.Encode()
-	db, err := sql.Open("sigmacomputing/gosnowflake", invalidDNS)
+	db, err := sql.Open("sigmacomputing+gosnowflake", invalidDNS)
 	if err != nil {
 		t.Fatalf("error creating a connection object: %s", err.Error())
 	}
@@ -391,7 +391,7 @@ func invalidHostErrorTests(invalidDNS string, mstr []string, t *testing.T) {
 	}
 	parameters.Add("loginTimeout", "10")
 	invalidDNS += "?" + parameters.Encode()
-	db, err := sql.Open("sigmacomputing/gosnowflake", invalidDNS)
+	db, err := sql.Open("sigmacomputing+gosnowflake", invalidDNS)
 	if err != nil {
 		t.Fatalf("error creating a connection object: %s", err.Error())
 	}
@@ -1480,7 +1480,7 @@ func TestValidateDatabaseParameter(t *testing.T) {
 			parameters.Add(k, v)
 		}
 		newDSN += "?" + parameters.Encode()
-		db, err := sql.Open("sigmacomputing/gosnowflake", newDSN)
+		db, err := sql.Open("sigmacomputing+gosnowflake", newDSN)
 		// actual connection won't happen until run a query
 		if err != nil {
 			t.Fatalf("error creating a connection object: %s", err.Error())
@@ -1509,7 +1509,7 @@ func TestSpecifyWarehouseDatabase(t *testing.T) {
 	if protocol != "" {
 		parameters.Add("protocol", protocol)
 	}
-	db, err := sql.Open("sigmacomputing/gosnowflake", dsn+"?"+parameters.Encode())
+	db, err := sql.Open("sigmacomputing+gosnowflake", dsn+"?"+parameters.Encode())
 	if err != nil {
 		t.Fatalf("error creating a connection object: %s", err.Error())
 	}
@@ -1552,7 +1552,7 @@ func TestPingInvalidHost(t *testing.T) {
 		t.Fatalf("failed to parse config. config: %v, err: %v", config, err)
 	}
 
-	db, err := sql.Open("sigmacomputing/gosnowflake", testURL)
+	db, err := sql.Open("sigmacomputing+gosnowflake", testURL)
 	if err != nil {
 		t.Fatalf("failed to initalize the connetion. err: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sigmacomputing/gosnowflake
+module github.com/sigmacomputing+gosnowflake
 
 go 1.19
 

--- a/priv_key_test.go
+++ b/priv_key_test.go
@@ -90,7 +90,7 @@ func TestJWTAuthentication(t *testing.T) {
 
 	// Test that a valid private key can pass
 	jwtDSN := appendPrivateKeyString(&dsn, testPrivKey)
-	db, err := sql.Open("snowflake", jwtDSN)
+	db, err := sql.Open("sigmacomputing/gosnowflake", jwtDSN)
 	if err != nil {
 		t.Fatalf("error creating a connection object: %s", err.Error())
 	}
@@ -105,7 +105,7 @@ func TestJWTAuthentication(t *testing.T) {
 		t.Error(err)
 	}
 	jwtDSN = appendPrivateKeyString(&dsn, invalidPrivateKey)
-	db, err = sql.Open("snowflake", jwtDSN)
+	db, err = sql.Open("sigmacomputing/gosnowflake", jwtDSN)
 	if err != nil {
 		t.Error(err)
 	}

--- a/priv_key_test.go
+++ b/priv_key_test.go
@@ -90,7 +90,7 @@ func TestJWTAuthentication(t *testing.T) {
 
 	// Test that a valid private key can pass
 	jwtDSN := appendPrivateKeyString(&dsn, testPrivKey)
-	db, err := sql.Open("sigmacomputing/gosnowflake", jwtDSN)
+	db, err := sql.Open("sigmacomputing+gosnowflake", jwtDSN)
 	if err != nil {
 		t.Fatalf("error creating a connection object: %s", err.Error())
 	}
@@ -105,7 +105,7 @@ func TestJWTAuthentication(t *testing.T) {
 		t.Error(err)
 	}
 	jwtDSN = appendPrivateKeyString(&dsn, invalidPrivateKey)
-	db, err = sql.Open("sigmacomputing/gosnowflake", jwtDSN)
+	db, err = sql.Open("sigmacomputing+gosnowflake", jwtDSN)
 	if err != nil {
 		t.Error(err)
 	}

--- a/statement_test.go
+++ b/statement_test.go
@@ -14,7 +14,7 @@ func openDB(t *testing.T) *sql.DB {
 	var db *sql.DB
 	var err error
 
-	if db, err = sql.Open("snowflake", dsn); err != nil {
+	if db, err = sql.Open("sigmacomputing/gosnowflake", dsn); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", dsn, err)
 	}
 	return db

--- a/statement_test.go
+++ b/statement_test.go
@@ -14,7 +14,7 @@ func openDB(t *testing.T) *sql.DB {
 	var db *sql.DB
 	var err error
 
-	if db, err = sql.Open("sigmacomputing/gosnowflake", dsn); err != nil {
+	if db, err = sql.Open("sigmacomputing+gosnowflake", dsn); err != nil {
 		t.Fatalf("failed to open db. %v, err: %v", dsn, err)
 	}
 	return db


### PR DESCRIPTION
### Description
sql register will panic if we use the name twice to register on init. If we want to be able to test a completely unforked version in parallel with our forked version, we need to change the name we use to register from our fork

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
