### PR TITLE
log request url and headers used to get execResponse

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -289,6 +289,7 @@ func (sc *snowflakeConn) getQueryResultResp(
 
 	// log to get data points for sf to debug cache issue, should log only for staging org
 	if shouldLogSfResponseForCacheBug(ctx) {
+		logger.WithContext(ctx).Errorf("request url: %s, headers: %v", url, headers)
 		logHeader, errHeader := json.Marshal(res.Header)
 		if errHeader != nil {
 			logger.WithContext(ctx).Errorf("failed to read header from result header. errHeader: %v", errHeader)
@@ -297,7 +298,6 @@ func (sc *snowflakeConn) getQueryResultResp(
 		// log for debugging header and response when Success is false but body has data
 		if !respd.Success && respd.Code == "" && respd.Message == "" {
 			logger.WithContext(ctx).Errorf("failed to build a proper exec response. received body: %s with header %s", string(bodyBytes), string(logHeader))
-			logger.WithContext(ctx).Errorf("request url: %s, headers: %v", url, headers)
 		}
 	}
 

--- a/monitoring.go
+++ b/monitoring.go
@@ -297,6 +297,7 @@ func (sc *snowflakeConn) getQueryResultResp(
 		// log for debugging header and response when Success is false but body has data
 		if !respd.Success && respd.Code == "" && respd.Message == "" {
 			logger.WithContext(ctx).Errorf("failed to build a proper exec response. received body: %s with header %s", string(bodyBytes), string(logHeader))
+			logger.WithContext(ctx).Errorf("request url: %s, headers: %v", url, headers)
 		}
 	}
 


### PR DESCRIPTION
### Description
I want to further point out to snowflake we get execResponse from which url and the response is broken. 

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
