### PR TITLE
[debug] Raise custom error on bad response.

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -133,7 +133,7 @@ func TestGetQueryResultUsesTokenFromTokenAccessor(t *testing.T) {
 		cfg:  &Config{Params: map[string]*string{}},
 		rest: sr,
 	}
-	if _, err := sc.getQueryResultResp(context.Background(), ""); err != nil {
+	if _, err := sc.getQueryResultResp(context.Background(), "", ""); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -256,6 +256,7 @@ const (
 	// ErrAsyncExecutionInProgress is returned when monitoring an async query reaches 45s
 	ErrAsyncExecutionInProgress = 333334
 
+	// ErrBadDriverResponse is returned when the driver receives a response from the server that is not compliant
 	ErrBadDriverResponse = 9999999
 )
 

--- a/errors.go
+++ b/errors.go
@@ -255,6 +255,8 @@ const (
 
 	// ErrAsyncExecutionInProgress is returned when monitoring an async query reaches 45s
 	ErrAsyncExecutionInProgress = 333334
+
+	ErrBadDriverResponse = 9999999
 )
 
 const (

--- a/monitoring.go
+++ b/monitoring.go
@@ -234,6 +234,7 @@ func shouldLogSfResponseForCacheBug(ctx context.Context) bool {
 func (sc *snowflakeConn) getQueryResultResp(
 	ctx context.Context,
 	resultPath string,
+	qid string,
 ) (*execResponse, error) {
 	var cachedResponse *execResponse
 	cachedResponse = nil
@@ -285,6 +286,13 @@ func (sc *snowflakeConn) getQueryResultResp(
 	// log when Success is false but body has data
 	if !respd.Success && respd.Code == "" && respd.Message == "" {
 		logger.WithContext(ctx).Errorf("Response body is non-empty but isSuccess is false")
+		return nil, &SnowflakeError{
+			Number:         ErrBadDriverResponse,
+			QueryID:        qid,
+			Message:        "We received a bad response from the server. Success was false but the code/error body empty",
+			MessageArgs:    nil,
+			IncludeQueryID: true,
+		}
 	}
 
 	// log to get data points for sf to debug cache issue, should log only for staging org
@@ -447,7 +455,7 @@ func (sc *snowflakeConn) rowsForRunningQuery(
 	ctx context.Context, qid string,
 	rows *snowflakeRows) error {
 	resultPath := fmt.Sprintf(urlQueriesResultFmt, qid)
-	resp, err := sc.getQueryResultResp(ctx, resultPath)
+	resp, err := sc.getQueryResultResp(ctx, resultPath, qid)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("error: %v", err)
 		if resp != nil {

--- a/multistatement.go
+++ b/multistatement.go
@@ -48,7 +48,7 @@ func (sc *snowflakeConn) handleMultiExec(
 			return nil, err
 		}
 		if isDml(childResultType) {
-			childData, err := sc.getQueryResultResp(ctx, resultPath)
+			childData, err := sc.getQueryResultResp(ctx, resultPath, child.id)
 			if err != nil {
 				logger.Errorf("error: %v", err)
 				return nil, err


### PR DESCRIPTION
### Description

When we receive bad message from the SF Warehouse we want to raise an error instead of defaulting to interpreting that as zero rows.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
