### PR TITLE
Remove the buggy, unreleased QueryContext in execResponseData

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -153,7 +153,9 @@ func (sc *snowflakeConn) exec(
 		return nil, err
 	}
 
-	sc.queryContextCache.add(data.Data.QueryContext.Entries...)
+
+	// Not released yet, we should add them after they are released
+	// sc.https://sigmacomputing.slack.com/archives/C01BL8JEMJ4/p1694101775726169.add(data.Data.QueryContext.Entries...)
 
 	// handle PUT/GET commands
 	if isFileTransfer(query) {

--- a/connection.go
+++ b/connection.go
@@ -155,7 +155,7 @@ func (sc *snowflakeConn) exec(
 
 
 	// Not released yet, we should add them after they are released
-	// sc.https://sigmacomputing.slack.com/archives/C01BL8JEMJ4/p1694101775726169.add(data.Data.QueryContext.Entries...)
+	// sc.queryContextCache.add(data.Data.QueryContext.Entries...)
 
 	// handle PUT/GET commands
 	if isFileTransfer(query) {

--- a/htap_test.go
+++ b/htap_test.go
@@ -101,36 +101,37 @@ func trimWhitespaces(s string) string {
 	)
 }
 
-func TestAddingQueryContextCacheEntry(t *testing.T) {
-	runSnowflakeConnTest(t, func(sc *snowflakeConn) {
-		t.Run("First query (may be on empty cache)", func(t *testing.T) {
-			entriesBefore := sc.queryContextCache.entries
-			if _, err := sc.Query("SELECT 1", nil); err != nil {
-				t.Fatalf("cannot query. %v", err)
-			}
-			entriesAfter := sc.queryContextCache.entries
+// Not released yet, we should add them after they are released
+// func TestAddingQueryContextCacheEntry(t *testing.T) {
+// 	runSnowflakeConnTest(t, func(sc *snowflakeConn) {
+// 		t.Run("First query (may be on empty cache)", func(t *testing.T) {
+// 			entriesBefore := sc.queryContextCache.entries
+// 			if _, err := sc.Query("SELECT 1", nil); err != nil {
+// 				t.Fatalf("cannot query. %v", err)
+// 			}
+// 			entriesAfter := sc.queryContextCache.entries
 
-			if !containsNewEntries(entriesAfter, entriesBefore) {
-				t.Error("no new entries added to the query context cache")
-			}
-		})
+// 			if !containsNewEntries(entriesAfter, entriesBefore) {
+// 				t.Error("no new entries added to the query context cache")
+// 			}
+// 		})
 
-		t.Run("Second query (cache should not be empty)", func(t *testing.T) {
-			entriesBefore := sc.queryContextCache.entries
-			if len(entriesBefore) == 0 {
-				t.Fatalf("cache should not be empty after first query")
-			}
-			if _, err := sc.Query("SELECT 1", nil); err != nil {
-				t.Fatalf("cannot query. %v", err)
-			}
-			entriesAfter := sc.queryContextCache.entries
+// 		t.Run("Second query (cache should not be empty)", func(t *testing.T) {
+// 			entriesBefore := sc.queryContextCache.entries
+// 			if len(entriesBefore) == 0 {
+// 				t.Fatalf("cache should not be empty after first query")
+// 			}
+// 			if _, err := sc.Query("SELECT 1", nil); err != nil {
+// 				t.Fatalf("cannot query. %v", err)
+// 			}
+// 			entriesAfter := sc.queryContextCache.entries
 
-			if !containsNewEntries(entriesAfter, entriesBefore) {
-				t.Error("no new entries added to the query context cache")
-			}
-		})
-	})
-}
+// 			if !containsNewEntries(entriesAfter, entriesBefore) {
+// 				t.Error("no new entries added to the query context cache")
+// 			}
+// 		})
+// 	})
+// }
 
 func containsNewEntries(entriesAfter []queryContextEntry, entriesBefore []queryContextEntry) bool {
 	if len(entriesAfter) > len(entriesBefore) {

--- a/query.go
+++ b/query.go
@@ -126,10 +126,11 @@ type execResponseData struct {
 	Kind                    string                `json:"kind,omitempty"`
 	Operation               string                `json:"operation,omitempty"`
 
-	// HTAP
-	QueryContext struct {
-		Entries []queryContextEntry `json:"entries,omitempty"`
-	} `json:"queryContext,omitempty"`
+	// Not released yet, we should add them when they are released
+	// // HTAP
+	// QueryContext struct {
+	// 	Entries []queryContextEntry `json:"entries,omitempty"`
+	// } `json:"queryContext,omitempty"`
 }
 
 type execResponse struct {


### PR DESCRIPTION
This code is on latest commit and are not officially released yet. They cased some issues when unmarshal things, removed for now, hopefully snowflake will have better testing and fix the bug when they release it. 