### PR TITLE
remove a line that caused multiplex crash

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -134,7 +134,6 @@ func (sc *snowflakeConn) exec(
 		jsonBody, sc.rest.RequestTimeout, requestID, sc.cfg)
 
 	if shouldLogSfResponseForCacheBug(ctx) {
-		logger.WithContext(ctx).Errorf("exec request body  %s, headers: %+v", string(jsonBody), headers)
 		logger.WithContext(ctx).Errorf("exec request response %+v", data)
 	}
 	if err != nil {


### PR DESCRIPTION
### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
