### PR TITLE
Add hook to log server version from auth response

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -35,28 +35,6 @@ const (
 // AuthType indicates the type of authentication in Snowflake
 type AuthType int
 
-type SessionMetadata struct {
-	ServerVersion string
-}
-
-type AuthSuccessHook func(context.Context, SessionMetadata)
-
-var authSuccessHook AuthSuccessHook
-
-// RegisterAuthSuccessHook registers a hook that can be used to extract metadata
-// from an auth response, such as the server version, for example, for logging
-// purposes. This function is not thread-safe, and should only be called once,
-// at startup.
-func RegisterAuthSuccessHook(hook AuthSuccessHook) {
-	authSuccessHook = hook
-}
-
-func logAuthSuccessMetadata(ctx context.Context, metadata SessionMetadata) {
-	if authSuccessHook != nil {
-		authSuccessHook(ctx, metadata)
-	}
-}
-
 const (
 	// AuthTypeSnowflake is the general username password authentication
 	AuthTypeSnowflake AuthType = iota

--- a/auth_success_hook.go
+++ b/auth_success_hook.go
@@ -1,0 +1,29 @@
+package gosnowflake
+
+import "context"
+
+// SessionMetadata contains metadata obtained from a successful authentication
+// response.
+type SessionMetadata struct {
+	ServerVersion string
+}
+
+// AuthSuccessHook is a user-provided callback that will be executed after a
+// successful authentication response.
+type AuthSuccessHook func(context.Context, SessionMetadata)
+
+var authSuccessHook AuthSuccessHook
+
+// RegisterAuthSuccessHook registers a hook that can be used to extract metadata
+// from an auth response, such as the server version, for example, for logging
+// purposes. This function is not thread-safe, and should only be called once,
+// at startup.
+func RegisterAuthSuccessHook(hook AuthSuccessHook) {
+	authSuccessHook = hook
+}
+
+func logAuthSuccessMetadata(ctx context.Context, metadata SessionMetadata) {
+	if authSuccessHook != nil {
+		authSuccessHook(ctx, metadata)
+	}
+}

--- a/auth_success_hook_test.go
+++ b/auth_success_hook_test.go
@@ -1,0 +1,50 @@
+package gosnowflake
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func postAuthSuccessWithServerVersion(_ context.Context, _ *snowflakeRestful, _ *http.Client, _ *url.Values, _ map[string]string, _ bodyCreatorType, _ time.Duration) (*authResponse, error) {
+	return &authResponse{
+		Success: true,
+		Data: authResponseMain{
+			Token:       "t",
+			MasterToken: "m",
+			SessionInfo: authResponseSessionInfo{
+				DatabaseName: "dbn",
+			},
+			ServerVersion: "123.456.7",
+		},
+	}, nil
+}
+
+func TestUnitLogAuthSuccessMetadata(t *testing.T) {
+	serverVersion := ""
+	RegisterAuthSuccessHook(func(_ context.Context, metadata SessionMetadata) {
+		serverVersion = metadata.ServerVersion
+	})
+	t.Cleanup(func() {
+		RegisterAuthSuccessHook(nil)
+	})
+
+	sr := &snowflakeRestful{
+		FuncPostAuth:  postAuthSuccessWithServerVersion,
+		TokenAccessor: getSimpleTokenAccessor(),
+	}
+	sc := getDefaultSnowflakeConn()
+	sc.ctx = context.TODO()
+	sc.rest = sr
+	sc.cfg.Authenticator = AuthTypeSnowflake
+
+	if err := authenticateWithConfig(sc); err != nil {
+		t.Fatalf("failed to run. err: %v", err)
+	}
+
+	if serverVersion != "123.456.7" {
+		t.Fatalf("Expected server version 123.456.7, got %v", serverVersion)
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -102,20 +102,6 @@ func postAuthSuccess(_ context.Context, _ *snowflakeRestful, _ *http.Client, _ *
 	}, nil
 }
 
-func postAuthSuccessWithServerVersion(_ context.Context, _ *snowflakeRestful, _ *http.Client, _ *url.Values, _ map[string]string, _ bodyCreatorType, _ time.Duration) (*authResponse, error) {
-	return &authResponse{
-		Success: true,
-		Data: authResponseMain{
-			Token:       "t",
-			MasterToken: "m",
-			SessionInfo: authResponseSessionInfo{
-				DatabaseName: "dbn",
-			},
-			ServerVersion: "123.456.7",
-		},
-	}, nil
-}
-
 func postAuthCheckSAMLResponse(_ context.Context, _ *snowflakeRestful, _ *http.Client, _ *url.Values, _ map[string]string, bodyCreator bodyCreatorType, _ time.Duration) (*authResponse, error) {
 	var ar authRequest
 	jsonBody, _ := bodyCreator()
@@ -697,33 +683,6 @@ func TestUnitAuthenticateExternalBrowser(t *testing.T) {
 	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatal("should have failed")
-	}
-}
-
-func TestUnitLogAuthSuccessMetadata(t *testing.T) {
-	serverVersion := ""
-	RegisterAuthSuccessHook(func(_ context.Context, metadata SessionMetadata) {
-		serverVersion = metadata.ServerVersion
-	})
-	t.Cleanup(func() {
-		RegisterAuthSuccessHook(nil)
-	})
-
-	sr := &snowflakeRestful{
-		FuncPostAuth:  postAuthSuccessWithServerVersion,
-		TokenAccessor: getSimpleTokenAccessor(),
-	}
-	sc := getDefaultSnowflakeConn()
-	sc.ctx = context.TODO()
-	sc.rest = sr
-	sc.cfg.Authenticator = AuthTypeSnowflake
-
-	if err := authenticateWithConfig(sc); err != nil {
-		t.Fatalf("failed to run. err: %v", err)
-	}
-
-	if serverVersion != "123.456.7" {
-		t.Fatalf("Expected server version 123.456.7, got %v", serverVersion)
 	}
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -102,6 +102,20 @@ func postAuthSuccess(_ context.Context, _ *snowflakeRestful, _ *http.Client, _ *
 	}, nil
 }
 
+func postAuthSuccessWithServerVersion(_ context.Context, _ *snowflakeRestful, _ *http.Client, _ *url.Values, _ map[string]string, _ bodyCreatorType, _ time.Duration) (*authResponse, error) {
+	return &authResponse{
+		Success: true,
+		Data: authResponseMain{
+			Token:       "t",
+			MasterToken: "m",
+			SessionInfo: authResponseSessionInfo{
+				DatabaseName: "dbn",
+			},
+			ServerVersion: "123.456.7",
+		},
+	}, nil
+}
+
 func postAuthCheckSAMLResponse(_ context.Context, _ *snowflakeRestful, _ *http.Client, _ *url.Values, _ map[string]string, bodyCreator bodyCreatorType, _ time.Duration) (*authResponse, error) {
 	var ar authRequest
 	jsonBody, _ := bodyCreator()
@@ -683,6 +697,33 @@ func TestUnitAuthenticateExternalBrowser(t *testing.T) {
 	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatal("should have failed")
+	}
+}
+
+func TestUnitLogAuthSuccessMetadata(t *testing.T) {
+	serverVersion := ""
+	RegisterAuthSuccessHook(func(_ context.Context, metadata SessionMetadata) {
+		serverVersion = metadata.ServerVersion
+	})
+	t.Cleanup(func() {
+		RegisterAuthSuccessHook(nil)
+	})
+
+	sr := &snowflakeRestful{
+		FuncPostAuth:  postAuthSuccessWithServerVersion,
+		TokenAccessor: getSimpleTokenAccessor(),
+	}
+	sc := getDefaultSnowflakeConn()
+	sc.ctx = context.TODO()
+	sc.rest = sr
+	sc.cfg.Authenticator = AuthTypeSnowflake
+
+	if err := authenticateWithConfig(sc); err != nil {
+		t.Fatalf("failed to run. err: %v", err)
+	}
+
+	if serverVersion != "123.456.7" {
+		t.Fatalf("Expected server version 123.456.7, got %v", serverVersion)
 	}
 }
 


### PR DESCRIPTION
### Description
Adds a hook to capture the server version field from a successful auth response,
e.g. to record the server version in trace events without relying on monitoring
data, which we do not always fetch.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
