### PR TITLE
[SIG-45543] return microsecond rather than nanosec in arrowToRecord() for timestamp tz/ntz/ltz to avoid future date overflow

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -1066,7 +1066,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 				for i := 0; i < int(numRows); i++ {
 					if !col.IsNull(i) {
 						val := time.Unix(epoch[i], int64(fraction[i]))
-						tb.Append(arrow.Timestamp(val.UnixNano()))
+						tb.Append(arrow.Timestamp(val.UnixMicro()))
 					} else {
 						tb.AppendNull()
 					}
@@ -1075,7 +1075,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 				for i, t := range col.(*array.Int64).Int64Values() {
 					if !col.IsNull(i) {
 						val := time.Unix(0, t*int64(math.Pow10(9-int(srcColumnMeta.Scale)))).UTC()
-						tb.Append(arrow.Timestamp(val.UnixNano()))
+						tb.Append(arrow.Timestamp(val.UnixMicro()))
 					} else {
 						tb.AppendNull()
 					}
@@ -1089,7 +1089,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 				for i, t := range timestampValues {
 					if !col.IsNull(i) {
 						val := time.Unix(0, int64(t)*int64(math.Pow10(9-int(srcColumnMeta.Scale)))).UTC()
-						tb.Append(arrow.Timestamp(val.UnixNano()))
+						tb.Append(arrow.Timestamp(val.UnixMicro()))
 					} else {
 						tb.AppendNull()
 					}
@@ -1108,7 +1108,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 				for i := 0; i < int(numRows); i++ {
 					if !col.IsNull(i) {
 						val := time.Unix(epoch[i], int64(fraction[i]))
-						tb.Append(arrow.Timestamp(val.UnixNano()))
+						tb.Append(arrow.Timestamp(val.UnixMicro()))
 					} else {
 						tb.AppendNull()
 					}
@@ -1119,7 +1119,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 						q := t / int64(math.Pow10(int(srcColumnMeta.Scale)))
 						r := t % int64(math.Pow10(int(srcColumnMeta.Scale)))
 						val := time.Unix(q, r)
-						tb.Append(arrow.Timestamp(val.UnixNano()))
+						tb.Append(arrow.Timestamp(val.UnixMicro()))
 					} else {
 						tb.AppendNull()
 					}
@@ -1135,7 +1135,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 						q := int64(t) / int64(math.Pow10(int(srcColumnMeta.Scale)))
 						r := int64(t) % int64(math.Pow10(int(srcColumnMeta.Scale)))
 						val := time.Unix(q, r)
-						tb.Append(arrow.Timestamp(val.UnixNano()))
+						tb.Append(arrow.Timestamp(val.UnixMicro()))
 					} else {
 						tb.AppendNull()
 					}
@@ -1166,7 +1166,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 						loc := Location(int(timezone[i]) - 1440)
 						tt := time.Unix(epoch[i], 0)
 						val := tt.In(loc)
-						tb.Append(arrow.Timestamp(val.UnixNano()))
+						tb.Append(arrow.Timestamp(val.UnixMicro()))
 					} else {
 						tb.AppendNull()
 					}
@@ -1195,7 +1195,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 						loc := Location(int(timezone[i]) - 1440)
 						tt := time.Unix(epoch[i], int64(fraction[i]))
 						val := tt.In(loc)
-						tb.Append(arrow.Timestamp(val.UnixNano()))
+						tb.Append(arrow.Timestamp(val.UnixMicro()))
 					} else {
 						tb.AppendNull()
 					}
@@ -1220,11 +1220,11 @@ func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.L
 		var t arrow.DataType
 		switch getSnowflakeType(strings.ToUpper(srcColumnMeta.Type)) {
 		case timeType:
-			t = &arrow.Time64Type{Unit: arrow.Nanosecond}
+			t = &arrow.Time64Type{Unit: arrow.Microsecond}
 		case timestampNtzType, timestampTzType:
-			t = &arrow.TimestampType{Unit: arrow.Nanosecond}
+			t = &arrow.TimestampType{Unit: arrow.Microsecond}
 		case timestampLtzType:
-			t = &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: loc.String()}
+			t = &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: loc.String()}
 		default:
 			converted = false
 		}

--- a/converter.go
+++ b/converter.go
@@ -1042,7 +1042,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 		newCol := col
 		switch getSnowflakeType(strings.ToUpper(srcColumnMeta.Type)) {
 		case timeType:
-			newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.FixedWidthTypes.Time64us))
+			newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.FixedWidthTypes.Time64ns))
 			if err != nil {
 				return nil, err
 			}
@@ -1220,7 +1220,7 @@ func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.L
 		var t arrow.DataType
 		switch getSnowflakeType(strings.ToUpper(srcColumnMeta.Type)) {
 		case timeType:
-			t = &arrow.Time64Type{Unit: arrow.Microsecond}
+			t = &arrow.Time64Type{Unit: arrow.Nanosecond}
 		case timestampNtzType, timestampTzType:
 			t = &arrow.TimestampType{Unit: arrow.Microsecond}
 		case timestampLtzType:

--- a/converter.go
+++ b/converter.go
@@ -1042,13 +1042,13 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 		newCol := col
 		switch getSnowflakeType(strings.ToUpper(srcColumnMeta.Type)) {
 		case timeType:
-			newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.FixedWidthTypes.Time64ns))
+			newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.FixedWidthTypes.Time64us))
 			if err != nil {
 				return nil, err
 			}
 			defer newCol.Release()
 		case timestampNtzType:
-			tb := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Nanosecond})
+			tb := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Microsecond})
 			if col.DataType().ID() == arrow.STRUCT {
 				structData := col.(*array.Struct)
 				epochArray, ok := structData.Field(0).(*array.Int64)
@@ -1099,7 +1099,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 			defer newCol.Release()
 			tb.Release()
 		case timestampLtzType:
-			tb := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: loc.String()})
+			tb := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: loc.String()})
 			if col.DataType().ID() == arrow.STRUCT {
 				structData := col.(*array.Struct)
 
@@ -1145,7 +1145,7 @@ func arrowToRecord(record arrow.Record, pool memory.Allocator, rowType []execRes
 			defer newCol.Release()
 			tb.Release()
 		case timestampTzType:
-			tb := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Nanosecond})
+			tb := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Microsecond})
 			structData, ok := col.(*array.Struct)
 			if !ok {
 				return nil, fmt.Errorf("expect type *array.Struct but get %s", col.DataType())

--- a/converter_test.go
+++ b/converter_test.go
@@ -930,7 +930,7 @@ func TestArrowToRecord(t *testing.T) {
 				srcvs := src.([]time.Time)
 				arr := convertedRec.Column(0).(*array.Time64)
 				for i := 0; i < arr.Len(); i++ {
-					if srcvs[i].UnixMicro() != int64(arr.Value(i)) {
+					if srcvs[i].UnixNano() != int64(arr.Value(i)) {
 						return i
 					}
 				}

--- a/converter_test.go
+++ b/converter_test.go
@@ -1021,7 +1021,6 @@ func TestArrowToRecord(t *testing.T) {
 				srcvs := src.([]time.Time)
 				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
 					if srcvs[i].UnixMicro() != int64(t) {
-						fmt.Println("srcvs[i].UnixMicro() {} int64(t) {}", srcvs[i].UnixMicro(), int64(t))
 						return i
 					}
 				}


### PR DESCRIPTION
### Description
https://github.com/snowflakedb/gosnowflake/issues/910
The last piece that blocks arrow batch. 
It's the "Year 2262" problem. 
The root cause is the int64, which is the underlying data representation of `arrow.Timestamp()` is  unable to support date beyond 2262 in nanosecond. 
`timestampNtzType`, `timestampLtzType`, `timestampTzType` from snowflake can return a future date that can't be represented by int64 in nanosecond. 

Since in Sigma system we use millisecond for now and there's microsecond WIP, we don't have any plans to support nanosecond. We can just transport microsecond in arrow batch to bypass this problem. 

This only affects arrow batch path and doesn't have impact on production code. 
I'll also make exporter/evaluator changes.  

### Question You Might Ask
Why we don't we use upstream fix?
There is no "real fix" to the problem. What upstream does is to add a validation check and return an error if overflow. However since we don't need nanosecond, we can return microsecond and bypass this year 2262 problem at all. 

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
